### PR TITLE
ci: add QEMU binary release workflow

### DIFF
--- a/.github/workflows/build-qemu-binaries.yml
+++ b/.github/workflows/build-qemu-binaries.yml
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2026 nilbox
+#
+# Build QEMU binaries for Linux and Windows, then publish as a GitHub Release.
+#
+# Trigger: manual (workflow_dispatch) with a qemu_version input.
+# Creates a release tag: qemu-v{version}
+#
+# Release assets:
+#   qemu-linux.tar.gz  — binary + BIOS files for Linux x86_64
+#   qemu-windows.zip   — exe + BIOS files + runtime DLLs for Windows x86_64
+
+name: Build QEMU Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      qemu_version:
+        description: "QEMU version to build (e.g. 10.2.0)"
+        required: true
+        default: "10.2.0"
+
+permissions:
+  contents: write
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Linux: static build inside Alpine container
+  # --------------------------------------------------------------------------
+  build-linux:
+    name: Build QEMU (Linux)
+    runs-on: ubuntu-22.04
+    container:
+      image: alpine:3.20
+
+    steps:
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache \
+            bash curl xz tar \
+            build-base ninja meson python3 pkg-config \
+            glib-static glib-dev \
+            pixman-dev \
+            zlib-static
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build QEMU (Linux static)
+        run: bash scripts/build-qemu-linux.sh "${{ inputs.qemu_version }}"
+
+      - name: Package Linux artifacts
+        run: |
+          BINARIES_DIR="apps/nilbox/src-tauri/binaries"
+          tar -czf qemu-linux.tar.gz -C "$BINARIES_DIR" linux/
+          echo "==> Archive: qemu-linux.tar.gz"
+          tar -tzvf qemu-linux.tar.gz
+
+      - name: Upload Linux archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: qemu-linux
+          path: qemu-linux.tar.gz
+          retention-days: 1
+
+  # --------------------------------------------------------------------------
+  # Windows: dynamic build using MSYS2 MinGW64
+  # --------------------------------------------------------------------------
+  build-windows:
+    name: Build QEMU (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2 MinGW64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-glib2
+            mingw-w64-x86_64-pixman
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-meson
+            mingw-w64-x86_64-python
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-diffutils
+            curl
+            tar
+            unzip
+            zip
+
+      - name: Build QEMU (Windows)
+        shell: msys2 {0}
+        run: bash scripts/build-qemu-windows.sh "${{ inputs.qemu_version }}"
+
+      - name: Package Windows artifacts
+        shell: msys2 {0}
+        run: |
+          BINARIES_DIR="apps/nilbox/src-tauri/binaries"
+          cd "$BINARIES_DIR"
+          zip -r "../../../../qemu-windows.zip" windows/
+          cd -
+          echo "==> Archive: qemu-windows.zip"
+          unzip -l qemu-windows.zip
+
+      - name: Upload Windows archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: qemu-windows
+          path: qemu-windows.zip
+          retention-days: 1
+
+  # --------------------------------------------------------------------------
+  # Release: create GitHub Release and attach both archives
+  # --------------------------------------------------------------------------
+  release:
+    name: Publish GitHub Release
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Download Linux archive
+        uses: actions/download-artifact@v4
+        with:
+          name: qemu-linux
+
+      - name: Download Windows archive
+        uses: actions/download-artifact@v4
+        with:
+          name: qemu-windows
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "qemu-v${{ inputs.qemu_version }}"
+          name: "QEMU ${{ inputs.qemu_version }} Binaries"
+          body: |
+            Pre-built QEMU ${{ inputs.qemu_version }} binaries for use with the nilbox Tauri app.
+
+            | Asset | Platform | Contents |
+            |-------|----------|----------|
+            | `qemu-linux.tar.gz` | Linux x86_64 | Static binary + BIOS/ROM files |
+            | `qemu-windows.zip` | Windows x86_64 | Exe + BIOS/ROM files + runtime DLLs |
+
+            **Usage** — download before `tauri build`:
+            ```bash
+            PLATFORM=linux  bash scripts/fetch-qemu-binaries.sh qemu-v${{ inputs.qemu_version }}
+            PLATFORM=windows bash scripts/fetch-qemu-binaries.sh qemu-v${{ inputs.qemu_version }}
+            ```
+          files: |
+            qemu-linux.tar.gz
+            qemu-windows.zip
+          make_latest: false

--- a/scripts/fetch-qemu-binaries.sh
+++ b/scripts/fetch-qemu-binaries.sh
@@ -11,48 +11,71 @@
 #
 # Environment variables:
 #   PLATFORM      - "linux" or "windows" (required)
-#   RELEASE_TAG   - GitHub release tag, defaults to "latest"
-#   GITHUB_REPO   - repository with pre-built binaries (default: nilbox-run/qemu-binaries)
+#   RELEASE_TAG   - GitHub release tag, e.g. "qemu-v10.2.0" (default: latest qemu-v* release)
+#   GITHUB_REPO   - repository with pre-built binaries (default: current repo via GITHUB_REPOSITORY,
+#                   or nilbox-run/nilbox as fallback)
 
 set -euo pipefail
 
 PLATFORM="${PLATFORM:-}"
-RELEASE_TAG="${1:-latest}"
-GITHUB_REPO="${GITHUB_REPO:-nilbox-run/qemu-binaries}"
+RELEASE_TAG="${1:-}"
+GITHUB_REPO="${GITHUB_REPO:-${GITHUB_REPOSITORY:-nilbox-run/nilbox}}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-OUT_DIR="$SCRIPT_DIR/../apps/nilbox/src-tauri/binaries"
+BINARIES_DIR="$SCRIPT_DIR/../apps/nilbox/src-tauri/binaries"
 
 if [ -z "$PLATFORM" ]; then
     echo "Error: PLATFORM environment variable must be set to 'linux' or 'windows'" >&2
     exit 1
 fi
 
-mkdir -p "$OUT_DIR"
+mkdir -p "$BINARIES_DIR"
 
-BASE_URL="https://github.com/$GITHUB_REPO/releases/$RELEASE_TAG/download"
+# Resolve release tag: if not given, find the latest qemu-v* release
+if [ -z "$RELEASE_TAG" ]; then
+    echo "==> Resolving latest qemu-v* release from $GITHUB_REPO ..."
+    RELEASE_TAG=$(curl -fsSL "https://api.github.com/repos/$GITHUB_REPO/releases" \
+        | grep '"tag_name"' \
+        | grep 'qemu-v' \
+        | head -1 \
+        | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    if [ -z "$RELEASE_TAG" ]; then
+        echo "Error: Could not find a qemu-v* release in $GITHUB_REPO" >&2
+        exit 1
+    fi
+    echo "==> Using release: $RELEASE_TAG"
+fi
+
+BASE_URL="https://github.com/$GITHUB_REPO/releases/download/$RELEASE_TAG"
 
 case "$PLATFORM" in
     linux)
-        TARGET_TRIPLE="x86_64-unknown-linux-gnu"
-        ARTIFACT="qemu-system-x86_64-$TARGET_TRIPLE"
-        echo "==> Downloading QEMU for Linux ($RELEASE_TAG)..."
-        curl -L -o "$OUT_DIR/$ARTIFACT" "$BASE_URL/$ARTIFACT"
-        chmod +x "$OUT_DIR/$ARTIFACT"
-        echo "==> Saved: $OUT_DIR/$ARTIFACT"
+        ARCHIVE="qemu-linux.tar.gz"
+        echo "==> Downloading $ARCHIVE from $RELEASE_TAG ..."
+        curl -fsSL -o "$BINARIES_DIR/$ARCHIVE" "$BASE_URL/$ARCHIVE"
+
+        echo "==> Extracting to $BINARIES_DIR/ ..."
+        tar -xzf "$BINARIES_DIR/$ARCHIVE" -C "$BINARIES_DIR/"
+        rm "$BINARIES_DIR/$ARCHIVE"
+
+        BINARY="$BINARIES_DIR/linux/qemu-system-x86_64-x86_64-unknown-linux-gnu"
+        chmod +x "$BINARY"
+        echo "==> Binary:  $BINARY"
+        echo "==> BIOS:    $(ls "$BINARIES_DIR/linux/"*.bin 2>/dev/null | tr '\n' ' ')"
         ;;
     windows)
-        TARGET_TRIPLE="x86_64-pc-windows-msvc"
-        ARTIFACT_EXE="qemu-system-x86_64-$TARGET_TRIPLE.exe"
-        ARTIFACT_DLL="qemu-windows-lib.zip"
-        echo "==> Downloading QEMU for Windows ($RELEASE_TAG)..."
-        curl -L -o "$OUT_DIR/$ARTIFACT_EXE" "$BASE_URL/$ARTIFACT_EXE"
-        curl -L -o "$OUT_DIR/$ARTIFACT_DLL" "$BASE_URL/$ARTIFACT_DLL"
-        mkdir -p "$OUT_DIR/lib"
-        unzip -o "$OUT_DIR/$ARTIFACT_DLL" -d "$OUT_DIR/lib"
-        rm "$OUT_DIR/$ARTIFACT_DLL"
-        echo "==> Saved: $OUT_DIR/$ARTIFACT_EXE"
-        echo "==> DLLs:  $OUT_DIR/lib/"
+        ARCHIVE="qemu-windows.zip"
+        echo "==> Downloading $ARCHIVE from $RELEASE_TAG ..."
+        curl -fsSL -o "$BINARIES_DIR/$ARCHIVE" "$BASE_URL/$ARCHIVE"
+
+        echo "==> Extracting to $BINARIES_DIR/ ..."
+        unzip -o "$BINARIES_DIR/$ARCHIVE" -d "$BINARIES_DIR/"
+        rm "$BINARIES_DIR/$ARCHIVE"
+
+        EXE="$BINARIES_DIR/windows/qemu-system-x86_64-x86_64-pc-windows-msvc.exe"
+        echo "==> Exe:     $EXE"
+        echo "==> DLLs:    $(ls "$BINARIES_DIR/windows/lib/"*.dll 2>/dev/null | wc -l) files"
+        echo "==> BIOS:    $(ls "$BINARIES_DIR/windows/"*.bin 2>/dev/null | tr '\n' ' ')"
         ;;
     *)
         echo "Error: PLATFORM must be 'linux' or 'windows'" >&2


### PR DESCRIPTION
## Summary

- Add `.github/workflows/build-qemu-binaries.yml` to build QEMU for Linux (Alpine static) and Windows (MSYS2), package as archives, and publish as a GitHub Release tagged `qemu-v{version}`
- Fix `scripts/fetch-qemu-binaries.sh`: switch to archive-based download so BIOS/ROM files are included, fix output paths to `binaries/linux/` and `binaries/windows/`, resolve `GITHUB_REPO` from `$GITHUB_REPOSITORY` env automatically

## How it works

**Build and release** (manual, run once per QEMU version change):
```
Actions → Build QEMU Binaries → qemu_version: 10.2.0
  ├── Linux job  (Alpine container) → qemu-linux.tar.gz  (binary + BIOS files)
  └── Windows job (MSYS2)          → qemu-windows.zip   (exe + DLLs + BIOS files)
       → GitHub Release: qemu-v10.2.0
```

**Before Tauri build** (CI or local):
```bash
PLATFORM=linux   bash scripts/fetch-qemu-binaries.sh qemu-v10.2.0
PLATFORM=windows bash scripts/fetch-qemu-binaries.sh qemu-v10.2.0
```

## Test plan

- [ ] Confirm `Build QEMU Binaries` workflow appears in the Actions tab after merge
- [ ] Run workflow manually with `qemu_version: 10.2.0`
- [ ] Verify `qemu-v10.2.0` release is created with `qemu-linux.tar.gz` and `qemu-windows.zip` assets
- [ ] Run `PLATFORM=linux bash scripts/fetch-qemu-binaries.sh qemu-v10.2.0` and confirm binary + BIOS files exist under `binaries/linux/`

Closes #2