### PR TITLE
fix: select first non-zero token path instead of summing all

### DIFF
--- a/crates/nilbox-core/src/proxy/token_extractor.rs
+++ b/crates/nilbox-core/src/proxy/token_extractor.rs
@@ -75,6 +75,7 @@ pub fn extract_from_sse_chunks(chunks: &[Vec<u8>], provider: &LlmProvider) -> Op
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(json_str) {
             let response_tokens = sum_token_paths(&value, resp_field);
             let request_tokens  = sum_token_paths(&value, req_field);
+
             if response_tokens > 0 || request_tokens > 0 {
                 let model = resolve_json_string(&value, mdl_field);
                 let total = request_tokens + response_tokens;
@@ -118,17 +119,23 @@ pub fn estimate_from_bytes_fallback(body_len: usize) -> TokenUsageData {
 
 // ── Helpers ──────────────────────────────────────────────────
 
-/// Sum token counts from a comma-separated list of JSON dot-paths.
+/// Pick the first non-zero value from a comma-separated list of JSON dot-paths.
 ///
-/// Example: `"usage.prompt_tokens,usage.completion_tokens"` → sum both fields.
+/// Comma-separated paths act as fallback alternatives, not a sum.
+/// Example: `"response.usage.output_tokens,usage.completion_tokens"` → try each
+/// path in order and return the first value > 0.
 fn sum_token_paths(value: &serde_json::Value, paths: &str) -> u32 {
     if paths.is_empty() {
         return 0;
     }
-    paths
-        .split(',')
-        .filter_map(|p| resolve_json_u32(value, p.trim()))
-        .sum()
+    for p in paths.split(',') {
+        if let Some(v) = resolve_json_u32(value, p.trim()) {
+            if v > 0 {
+                return v;
+            }
+        }
+    }
+    0
 }
 
 /// Resolve a dot-separated JSON path to a u32 value.


### PR DESCRIPTION
## Summary
Fixes incorrect token counting where `sum_token_paths()` was summing all comma-separated field paths instead of selecting the first non-zero value.

## Problem
When `response_token_field` contained multiple paths (e.g., `"response.usage.output_tokens,response.usage.total_tokens"`), the function summed all resolved values, inflating output token counts.

**Example:**
- `response.usage.output_tokens` = 82
- `response.usage.total_tokens` = 12235
- **Incorrect result:** 82 + 12235 = 12317
- **Correct result:** 82 (first non-zero path)

## Solution
Changed `sum_token_paths()` to treat comma-separated paths as fallback alternatives. Returns the first path that resolves to a value > 0, ignoring remaining paths.

## Impact
- Fixes Statistics → Recent Requests token display
- Corrects token usage aggregates (daily/weekly/monthly)
- Prevents premature token limit triggers

## Test Plan
- [x] Code compiles (cargo check)
- [x] Existing tests pass
- Verify token counts in Statistics tab match actual API responses

---
🤖 Generated with Claude Code