### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,7 +3470,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nilbox"
-version = "0.1.8"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "nilbox-blocklist"
-version = "0.1.8"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "nilbox-core"
-version = "0.1.8"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "nilbox-mcp-bridge"
-version = "0.1.8"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.8"
+version = "0.2.1"
 edition = "2021"
 license = "GPL-3.0-or-later"
 

--- a/apps/nilbox/src-tauri/tauri.conf.json
+++ b/apps/nilbox/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "nilbox",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "run.nilbox.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bump app version from 0.2.0 to 0.2.1
- Updated `Cargo.toml` (workspace version: 0.1.8 → 0.2.1)
- Updated `apps/nilbox/src-tauri/tauri.conf.json` (0.2.0 → 0.2.1)