### PR TITLE
fix: prevent certutil -N hang on existing NSS DB in VM image builds

### DIFF
--- a/scripts/build-debian-image-linux.sh
+++ b/scripts/build-debian-image-linux.sh
@@ -530,6 +530,75 @@ rm -rf /mnt/debian/var/cache/apt/ /mnt/debian/var/lib/apt/lists/
 echo "nameserver 127.0.0.53" > /mnt/debian/etc/resolv.conf
 echo "[container] Python certifi installed"
 
+# ── 4i.8: Install libnss3-tools + initialize root NSS database ──
+# Chrome/Chromium on Linux uses NSS for certificate validation.
+# The NilBox Inspect CA will be registered into this database at VM start
+# (via handle_update_ca_certificates in vm-agent), so certutil must be available.
+echo "[container] Installing libnss3-tools and initializing NSS database..."
+cp /etc/resolv.conf /mnt/debian/etc/resolv.conf
+chroot /mnt/debian env DEBIAN_FRONTEND=noninteractive \
+    apt-get update -qq \
+    -o Acquire::http::Proxy="" -o Acquire::https::Proxy=""
+chroot /mnt/debian env DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+    -o Acquire::http::Proxy="" -o Acquire::https::Proxy="" \
+    libnss3-tools
+rm -rf /mnt/debian/var/cache/apt/ /mnt/debian/var/lib/apt/lists/
+echo "nameserver 127.0.0.53" > /mnt/debian/etc/resolv.conf
+echo "[container] libnss3-tools installed"
+
+# Pre-create the NSS database at build time so the runtime service never
+# invokes `certutil -N`. Running `-N` against an existing SQL NSS DB triggers
+# a softoken busy-loop that burns 100% CPU indefinitely (see bug: certutil
+# hangs when re-initializing an existing sql: database).
+chroot /mnt/debian install -d /home/nilbox/.pki
+chroot /mnt/debian install -d /home/nilbox/.pki/nssdb
+chroot /mnt/debian certutil -N -d sql:/home/nilbox/.pki/nssdb --empty-password
+chroot /mnt/debian chown -R nilbox:nilbox /home/nilbox/.pki
+echo "[container] NSS DB pre-created at /home/nilbox/.pki/nssdb"
+
+# systemd path unit: watch for CA cert and register it in Chrome NSS database.
+# Runs certutil as a small oneshot service (not forked from vm-agent) to avoid OOM.
+cat > /mnt/debian/etc/systemd/system/nilbox-nssdb.path << 'EOF'
+[Unit]
+Description=Watch for NilBox Inspect CA certificate
+
+[Path]
+PathExists=/usr/local/share/ca-certificates/nilbox-inspect.crt
+PathChanged=/usr/local/share/ca-certificates/nilbox-inspect.crt
+Unit=nilbox-nssdb.service
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > /mnt/debian/etc/systemd/system/nilbox-nssdb.service << 'EOF'
+[Unit]
+Description=Register NilBox Inspect CA in Chrome NSS database
+After=local-fs.target
+
+[Service]
+Type=oneshot
+User=nilbox
+# Safety net: recreate DB only if missing. The image ships with a pre-created DB,
+# so this branch normally does nothing. Never run `-N` against an existing DB —
+# NSS softoken spins at 100% CPU in that path.
+ExecStartPre=/bin/bash -c 'mkdir -p /home/nilbox/.pki/nssdb && \
+    [ -f /home/nilbox/.pki/nssdb/cert9.db ] || \
+    certutil -N -d sql:/home/nilbox/.pki/nssdb --empty-password'
+# Idempotent add: skip if the CA is already registered, so path-unit retriggers
+# (e.g. CA cert rewritten) do not fail with SEC_ERROR_ADDING_CERT.
+ExecStart=/bin/bash -c 'certutil -L -d sql:/home/nilbox/.pki/nssdb \
+    | grep -q "NilBox Inspect CA" || \
+    certutil -A -n "NilBox Inspect CA" -t "CT,," \
+        -i /usr/local/share/ca-certificates/nilbox-inspect.crt \
+        -d sql:/home/nilbox/.pki/nssdb'
+RemainAfterExit=no
+EOF
+
+chroot /mnt/debian systemctl enable nilbox-nssdb.path
+echo "[container] nilbox-nssdb path unit installed and enabled"
+
 # ── 4j: initramfs virtio modules ──
 echo "[container] Updating initramfs with virtio modules..."
 

--- a/scripts/build-debian-image-macos.sh
+++ b/scripts/build-debian-image-macos.sh
@@ -542,6 +542,16 @@ rm -rf /mnt/debian/var/cache/apt/ /mnt/debian/var/lib/apt/lists/
 echo "nameserver 127.0.0.53" > /mnt/debian/etc/resolv.conf
 echo "[container] libnss3-tools installed"
 
+# Pre-create the NSS database at build time so the runtime service never
+# invokes `certutil -N`. Running `-N` against an existing SQL NSS DB triggers
+# a softoken busy-loop that burns 100% CPU indefinitely (see bug: certutil
+# hangs when re-initializing an existing sql: database).
+chroot /mnt/debian install -d /home/nilbox/.pki
+chroot /mnt/debian install -d /home/nilbox/.pki/nssdb
+chroot /mnt/debian certutil -N -d sql:/home/nilbox/.pki/nssdb --empty-password
+chroot /mnt/debian chown -R nilbox:nilbox /home/nilbox/.pki
+echo "[container] NSS DB pre-created at /home/nilbox/.pki/nssdb"
+
 # systemd path unit: watch for CA cert and register it in Chrome NSS database.
 # Runs certutil as a small oneshot service (not forked from vm-agent) to avoid OOM.
 cat > /mnt/debian/etc/systemd/system/nilbox-nssdb.path << 'EOF'
@@ -565,11 +575,19 @@ After=local-fs.target
 [Service]
 Type=oneshot
 User=nilbox
-# Initialize the NSS database at runtime (chroot init is unreliable)
-ExecStartPre=/bin/bash -c 'mkdir -p /home/nilbox/.pki/nssdb && certutil -N -d sql:/home/nilbox/.pki/nssdb --empty-password 2>/dev/null || true'
-ExecStart=/usr/bin/certutil -A -n "NilBox Inspect CA" -t "CT,," \
-    -i /usr/local/share/ca-certificates/nilbox-inspect.crt \
-    -d sql:/home/nilbox/.pki/nssdb
+# Safety net: recreate DB only if missing. The image ships with a pre-created DB,
+# so this branch normally does nothing. Never run `-N` against an existing DB —
+# NSS softoken spins at 100% CPU in that path.
+ExecStartPre=/bin/bash -c 'mkdir -p /home/nilbox/.pki/nssdb && \
+    [ -f /home/nilbox/.pki/nssdb/cert9.db ] || \
+    certutil -N -d sql:/home/nilbox/.pki/nssdb --empty-password'
+# Idempotent add: skip if the CA is already registered, so path-unit retriggers
+# (e.g. CA cert rewritten) do not fail with SEC_ERROR_ADDING_CERT.
+ExecStart=/bin/bash -c 'certutil -L -d sql:/home/nilbox/.pki/nssdb \
+    | grep -q "NilBox Inspect CA" || \
+    certutil -A -n "NilBox Inspect CA" -t "CT,," \
+        -i /usr/local/share/ca-certificates/nilbox-inspect.crt \
+        -d sql:/home/nilbox/.pki/nssdb'
 RemainAfterExit=no
 EOF
 
@@ -660,9 +678,11 @@ rm -f /mnt/debian/etc/ssh/moduli
 # Only remove higher-level dist-packages
 rm -rf /mnt/debian/usr/lib/python3/dist-packages/
 # Keep: /usr/bin/python3, /usr/lib/python3/
-# Remove dpkg records for python3-pip so guest 'apt-get install python3-pip' reinstalls properly.
+# Remove dpkg records for python3-pip and its deps whose files were wiped above,
+# so guest 'apt-get install python3-pip' reinstalls cleanly instead of trying to
+# reconfigure a broken python3-wheel (missing dist-packages/wheel → py3compile fail).
 # (certifi was installed via pip to /usr/local/lib, so it is preserved above)
-chroot /mnt/debian dpkg --remove --force-depends python3-pip python3-pip-whl 2>/dev/null || true
+chroot /mnt/debian dpkg --remove --force-depends python3-pip python3-pip-whl python3-wheel 2>/dev/null || true
 
 # dpkg/apt — kept for runtime package installation
 # (var/lib/apt/lists/ already removed above; re-run: apt-get update && apt-get install ...)

--- a/scripts/build-debian-image-win.sh
+++ b/scripts/build-debian-image-win.sh
@@ -512,6 +512,75 @@ rm -rf /mnt/debian/var/cache/apt/ /mnt/debian/var/lib/apt/lists/
 echo "nameserver 127.0.0.53" > /mnt/debian/etc/resolv.conf
 echo "[container] Python certifi installed"
 
+# ── 4i.8: Install libnss3-tools + initialize root NSS database ──
+# Chrome/Chromium on Linux uses NSS for certificate validation.
+# The NilBox Inspect CA will be registered into this database at VM start
+# (via handle_update_ca_certificates in vm-agent), so certutil must be available.
+echo "[container] Installing libnss3-tools and initializing NSS database..."
+cp /etc/resolv.conf /mnt/debian/etc/resolv.conf
+chroot /mnt/debian env DEBIAN_FRONTEND=noninteractive \
+    apt-get update -qq \
+    -o Acquire::http::Proxy="" -o Acquire::https::Proxy=""
+chroot /mnt/debian env DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+    -o Acquire::http::Proxy="" -o Acquire::https::Proxy="" \
+    libnss3-tools
+rm -rf /mnt/debian/var/cache/apt/ /mnt/debian/var/lib/apt/lists/
+echo "nameserver 127.0.0.53" > /mnt/debian/etc/resolv.conf
+echo "[container] libnss3-tools installed"
+
+# Pre-create the NSS database at build time so the runtime service never
+# invokes `certutil -N`. Running `-N` against an existing SQL NSS DB triggers
+# a softoken busy-loop that burns 100% CPU indefinitely (see bug: certutil
+# hangs when re-initializing an existing sql: database).
+chroot /mnt/debian install -d /home/nilbox/.pki
+chroot /mnt/debian install -d /home/nilbox/.pki/nssdb
+chroot /mnt/debian certutil -N -d sql:/home/nilbox/.pki/nssdb --empty-password
+chroot /mnt/debian chown -R nilbox:nilbox /home/nilbox/.pki
+echo "[container] NSS DB pre-created at /home/nilbox/.pki/nssdb"
+
+# systemd path unit: watch for CA cert and register it in Chrome NSS database.
+# Runs certutil as a small oneshot service (not forked from vm-agent) to avoid OOM.
+cat > /mnt/debian/etc/systemd/system/nilbox-nssdb.path << 'EOF'
+[Unit]
+Description=Watch for NilBox Inspect CA certificate
+
+[Path]
+PathExists=/usr/local/share/ca-certificates/nilbox-inspect.crt
+PathChanged=/usr/local/share/ca-certificates/nilbox-inspect.crt
+Unit=nilbox-nssdb.service
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > /mnt/debian/etc/systemd/system/nilbox-nssdb.service << 'EOF'
+[Unit]
+Description=Register NilBox Inspect CA in Chrome NSS database
+After=local-fs.target
+
+[Service]
+Type=oneshot
+User=nilbox
+# Safety net: recreate DB only if missing. The image ships with a pre-created DB,
+# so this branch normally does nothing. Never run `-N` against an existing DB —
+# NSS softoken spins at 100% CPU in that path.
+ExecStartPre=/bin/bash -c 'mkdir -p /home/nilbox/.pki/nssdb && \
+    [ -f /home/nilbox/.pki/nssdb/cert9.db ] || \
+    certutil -N -d sql:/home/nilbox/.pki/nssdb --empty-password'
+# Idempotent add: skip if the CA is already registered, so path-unit retriggers
+# (e.g. CA cert rewritten) do not fail with SEC_ERROR_ADDING_CERT.
+ExecStart=/bin/bash -c 'certutil -L -d sql:/home/nilbox/.pki/nssdb \
+    | grep -q "NilBox Inspect CA" || \
+    certutil -A -n "NilBox Inspect CA" -t "CT,," \
+        -i /usr/local/share/ca-certificates/nilbox-inspect.crt \
+        -d sql:/home/nilbox/.pki/nssdb'
+RemainAfterExit=no
+EOF
+
+chroot /mnt/debian systemctl enable nilbox-nssdb.path
+echo "[container] nilbox-nssdb path unit installed and enabled"
+
 # ── 4j: initramfs virtio modules ──
 echo "[container] Updating initramfs with virtio modules..."
 


### PR DESCRIPTION
## Summary
- Fix 100% CPU hang in `nilbox-nssdb.service` caused by `certutil -N --empty-password` re-running against an already-initialized NSS DB (NSS softoken enters a userspace busy-loop instead of exiting).
- Apply three orthogonal defenses so first boot, subsequent boots, and path-unit retriggers all remain clean.
- Port the NSS stanza (Chrome CA trust via libnss3-tools + systemd path unit) to the Linux and Windows build scripts, which previously had no NSS support at all.

## Changes
- **Pre-create NSS DB at build time** — run `certutil -N` once inside the chroot and chown to `nilbox`. The shipped image already contains `cert9.db`/`key4.db`/`pkcs11.txt`, so the runtime service never executes the hang-prone path.
- **ExecStartPre guard** — `[ -f cert9.db ] || certutil -N …` as a safety net for DB corruption / manual deletion.
- **ExecStart idempotent** — `certutil -L | grep -q "NilBox Inspect CA" || certutil -A …` so path-unit retriggers (host rewriting the CA file) no longer fail with `SEC_ERROR_ADDING_CERT`.
- `build-debian-image-linux.sh` / `build-debian-image-win.sh` gain the full 4i.8 NSS stanza (libnss3-tools install, path+service units, pre-created DB).

Fixes #15.

## Evidence (from affected VM)
```
$ ps -o pid,stat,wchan,cmd -p 348
    PID STAT WCHAN  CMD
    348 R    -      certutil -N -d sql:/home/nilbox/.pki/nssdb --empty-password
$ systemctl status nilbox-nssdb.service
  Active: activating (start-pre) since Mon 2026-04-20 00:52:05 UTC; 1min 21s ago
     CPU: 1min 21.223s
```
`WCHAN: -` + `State: R` = userspace busy-loop. virtio_rng loaded, `/dev/hwrng` present → not entropy. No lock file in `nssdb/` → not DB lock contention. NSS DB files were created on the first boot (2026-04-17); subsequent boot (2026-04-20) re-runs `-N` on the existing DB and hangs.

## Regression note
Earlier history (qemu-tauri commit `7324b92`) moved certutil out of `vm-agent` into this systemd oneshot service specifically to avoid `vm-agent` fork-OOM on low-RAM guests. All changes here stay inside the already-separated oneshot service — `vm-agent` still does not fork certutil, so that OOM class is not reintroduced.

## Test plan
- [x] `./scripts/build-debian-image-macos.sh` completes; step 4i.8 logs `NSS DB pre-created at /home/nilbox/.pki/nssdb`.
- [x] First boot: `systemctl status nilbox-nssdb.service` reaches `inactive (dead)` within seconds; no lingering `certutil` process.
- [x] Reboot: same state, no `certutil -N` spin.
- [x] `sudo certutil -L -d sql:/home/nilbox/.pki/nssdb` lists `NilBox Inspect CA CT,,`.
- [x] Manually delete `/home/nilbox/.pki/nssdb/*`, touch the CA file → ExecStartPre safety net recreates DB, ExecStart re-registers CA, service ends clean.
- [x] Re-trigger path unit with CA already registered → service succeeds (no `SEC_ERROR_ADDING_CERT`).
- [ ] Linux / Windows images: build succeeds; Chrome/Chromium trusts the Inspect CA without warnings.