### PR TITLE
fix: auto-refresh store access token on expiry and 401 responses

### DIFF
--- a/crates/nilbox-core/src/service.rs
+++ b/crates/nilbox-core/src/service.rs
@@ -2036,14 +2036,10 @@ impl NilBoxService {
         // so we can register the app in the DB when install completes.
         // (app_id, app_name, inbound_ports, admin_urls, functions)
         let install_app_info: Option<(String, String, Vec<u16>, Vec<(String, String)>, Vec<(String, String)>)> = if let Some(url) = install_url {
-            let mut req = reqwest::Client::new().get(url);
-            // Only inject store token for store.nilbox.run to prevent token leakage to arbitrary hosts
-            if url.starts_with(crate::store::STORE_BASE_URL) {
-                if let Some(token) = self.state.store_auth.access_token().await {
-                    req = req.header("Authorization", format!("Bearer {}", token));
-                }
-            }
-            match req.send().await {
+            // fetch_store_url only attaches the bearer for STORE_BASE_URL hosts
+            // (avoids leaking the token to arbitrary hosts) and refreshes once
+            // on 401 if the server-side has revoked the cached token.
+            match self.fetch_store_url(url).await {
                 Ok(resp) if resp.status().is_success() => {
                     match resp.json::<serde_json::Value>().await {
                         Ok(raw) => {
@@ -2962,16 +2958,9 @@ impl NilBoxService {
         use crate::store::envelope::parse_envelope;
         use crate::store::verify::verify_envelope;
 
-        // 1. Fetch manifest from store
-        let client = reqwest::Client::new();
-        let mut req = client.get(manifest_url);
-        // Only inject store token for store.nilbox.run to prevent token leakage to arbitrary hosts
-        if manifest_url.starts_with(crate::store::STORE_BASE_URL) {
-            if let Some(token) = self.state.store_auth.access_token().await {
-                req = req.header("Authorization", format!("Bearer {}", token));
-            }
-        }
-        let resp = req.send().await
+        // 1. Fetch manifest from store. fetch_store_url scopes the bearer to
+        // STORE_BASE_URL hosts and refreshes once on 401.
+        let resp = self.fetch_store_url(manifest_url).await
             .map_err(|e| anyhow!("Failed to fetch manifest: {}", e))?;
         if !resp.status().is_success() {
             return Err(anyhow!("Manifest fetch failed: HTTP {}", resp.status()));
@@ -3258,6 +3247,34 @@ impl NilBoxService {
 
     pub async fn store_access_token(&self) -> Option<String> {
         self.state.store_auth.access_token().await
+    }
+
+    /// GET a store URL with the current bearer token, transparently refreshing
+    /// once on 401. Bearer is only attached when `url` targets `STORE_BASE_URL`.
+    async fn fetch_store_url(&self, url: &str) -> reqwest::Result<reqwest::Response> {
+        let client = reqwest::Client::new();
+        let is_store = url.starts_with(crate::store::STORE_BASE_URL);
+
+        let send_with_token = |token: Option<String>| {
+            let mut req = client.get(url);
+            if let Some(t) = token {
+                req = req.header("Authorization", format!("Bearer {}", t));
+            }
+            req.send()
+        };
+
+        let token = if is_store { self.state.store_auth.access_token().await } else { None };
+        let resp = send_with_token(token).await?;
+
+        // Server may have revoked the token even though our cached `exp` is in
+        // the future. Force a refresh and retry once.
+        if is_store && resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+            warn!("fetch_store_url: 401 from {}, attempting one refresh+retry", url);
+            if let Some(fresh) = self.state.store_auth.force_refresh_access_token().await {
+                return send_with_token(Some(fresh)).await;
+            }
+        }
+        Ok(resp)
     }
 
     /// JWT access token에서 `verified` 클레임을 추출합니다.

--- a/crates/nilbox-core/src/store/auth.rs
+++ b/crates/nilbox-core/src/store/auth.rs
@@ -12,6 +12,11 @@ use crate::keystore::KeyStore;
 const STORE_REFRESH_TOKEN: &str = "store:refresh_token";
 const STORE_EMAIL: &str = "store:email";
 
+/// Refresh the access token if its JWT `exp` is within this many seconds.
+/// Gives `access_token()` callers a small grace window so a request issued
+/// "right at the edge" doesn't race the server-side expiry.
+const REFRESH_LEEWAY_SECS: i64 = 60;
+
 #[derive(Debug, Deserialize)]
 struct SessionResponse {
     session_id: String,
@@ -399,7 +404,36 @@ impl StoreAuth {
     }
 
     /// Get the current access token (for HTTP requests).
+    ///
+    /// Lazily refreshes when the cached JWT's `exp` claim is within
+    /// `REFRESH_LEEWAY_SECS` (or already past). Returns `None` only when no
+    /// token is held at all *and* refresh is impossible (no refresh token, or
+    /// the refresh request itself failed and cleared state).
     pub async fn access_token(&self) -> Option<String> {
+        let cached = self.access_token.read().await.clone();
+        match cached {
+            Some(t) if !is_jwt_near_expiry(&t, REFRESH_LEEWAY_SECS) => Some(t),
+            Some(_) => {
+                debug!("access_token: cached JWT near/past expiry, refreshing");
+                if let Err(e) = self.refresh().await {
+                    warn!("access_token: refresh failed: {}", e);
+                    return None;
+                }
+                self.access_token.read().await.clone()
+            }
+            None => None,
+        }
+    }
+
+    /// Force a refresh using the stored refresh token, then return the new
+    /// access token. Used by callers that just received a 401 from upstream
+    /// even though the cached `exp` was still in the future (server-side
+    /// revocation, clock skew, policy change, etc.).
+    pub async fn force_refresh_access_token(&self) -> Option<String> {
+        if let Err(e) = self.refresh().await {
+            warn!("force_refresh_access_token: refresh failed: {}", e);
+            return None;
+        }
         self.access_token.read().await.clone()
     }
 
@@ -532,6 +566,34 @@ impl StoreAuth {
 
         Ok(info.email)
     }
+}
+
+// ── JWT helpers ──────────────────────────────────────────────
+
+/// Decode a JWT's `exp` claim (seconds since epoch). Signature is NOT verified —
+/// the token has already been authenticated when received over TLS from the
+/// store, and we only need the expiry hint for client-side caching decisions.
+fn jwt_exp(token: &str) -> Option<i64> {
+    let payload = token.splitn(3, '.').nth(1)?;
+    let padded = format!("{}{}", payload, "=".repeat((4 - payload.len() % 4) % 4));
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE};
+    let decoded = URL_SAFE.decode(&padded).ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    claims.get("exp")?.as_i64()
+}
+
+/// True if the JWT will expire within `leeway` seconds (or already has, or has
+/// no `exp` claim — in which case we conservatively treat it as expiring).
+fn is_jwt_near_expiry(token: &str, leeway: i64) -> bool {
+    let exp = match jwt_exp(token) {
+        Some(v) => v,
+        None => return true,
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    exp - now <= leeway
 }
 
 // ── Legacy file migration helpers ─────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the issue where the Store menu shows the user as logged in, but clicking **Install** fails with `HTTP 401 Unauthorized` on the manifest fetch.

### Root cause

`StoreAuth` had no expiry handling. Once the JWT access token's TTL elapsed after app startup, all bearer-authenticated requests to store.nilbox.run would silently fail with 401, while the UI kept reporting logged-in (based on stale in-memory/cached state).

### Solution

Two-pronged token refresh strategy:

1. **Lazy refresh on `access_token()` call**: Decode the JWT `exp` claim and refresh preemptively when within 60 seconds of expiry. Avoids the "token expired but we don't know it yet" scenario.

2. **Force refresh+retry on 401**: New `fetch_store_url()` helper detects 401 from store.nilbox.run (the only place we attach bearer) and attempts one refresh+retry. Handles server-side revocation, logout elsewhere, or policy changes that can invalidate the token even though our cached `exp` is still in the future.

### Changes

**`crates/nilbox-core/src/store/auth.rs`**
- `access_token()` now decodes JWT `exp` and calls `refresh()` when expiry is imminent (60s leeway).
- New `force_refresh_access_token()` method for explicit refresh after detecting 401.
- New `jwt_exp()` and `is_jwt_near_expiry()` helpers to parse/check expiry without signature verification (token is already authenticated via TLS at receipt time).
- New constant `REFRESH_LEEWAY_SECS = 60`.

**`crates/nilbox-core/src/service.rs`**
- New private `fetch_store_url()` helper that:
  - Only attaches bearer for `STORE_BASE_URL` hosts (prevents token leakage).
  - Detects 401 and calls `force_refresh_access_token()` once, then retries.
  - Returns the response for the caller to handle success/failure.
- Updated both manifest-fetch call sites to use the helper:
  - `open_shell` install path (line 2038).
  - `store_install_app` (line 2960).

### Behavior

- Access token naturally expired → `access_token()` detects and refreshes → manifest fetch succeeds.
- Server revoked the token mid-session → first request gets 401 → helper refreshes and retries → succeeds.
- Refresh token also expired → `refresh()` clears tokens and returns error → `auth_status()` reports logged-out → UI corrects itself.

### Testing

Manual test plan:
1. Log in to Store.
2. Simulate token expiry (server-side invalidate, or wait for TTL).
3. Try to install an app → should succeed via lazy refresh or 401 retry.
4. Simulate refresh token expiry → should show logged-out in UI.