### PR TITLE
feat: display VM image version info in Settings

### DIFF
--- a/apps/nilbox/src/components/screens/Settings.tsx
+++ b/apps/nilbox/src/components/screens/Settings.tsx
@@ -13,8 +13,10 @@ import {
   setCdpBrowser as setCdpBrowserApi,
   getCdpOpenMode,
   setCdpOpenMode as setCdpOpenModeApi,
+  listVms,
   UpdateInfo,
   ForceUpgradeInfo,
+  VmInfo,
 } from "../../lib/tauri";
 
 interface SettingsProps {
@@ -38,6 +40,7 @@ export const Settings: React.FC<SettingsProps> = ({ developerMode, onDeveloperMo
   const [currentVersion, setCurrentVersion] = useState<string>("");
   const [cdpBrowser, setCdpBrowser] = useState<string>("chrome");
   const [cdpOpenMode, setCdpOpenMode] = useState<string>("auto");
+  const [vmList, setVmList] = useState<VmInfo[]>([]);
 
   useEffect(() => {
     getUpdateSettings().then((s) => {
@@ -54,6 +57,7 @@ export const Settings: React.FC<SettingsProps> = ({ developerMode, onDeveloperMo
     getVersion().then(setCurrentVersion).catch(() => {});
     getCdpBrowser().then(setCdpBrowser).catch(() => {});
     getCdpOpenMode().then(setCdpOpenMode).catch(() => {});
+    listVms().then(setVmList).catch(() => {});
   }, []);
 
   const handleLanguageChange = (lang: string) => {
@@ -508,6 +512,52 @@ export const Settings: React.FC<SettingsProps> = ({ developerMode, onDeveloperMo
             </div>
           </div>
         </label>
+      </div>
+
+      {/* VM Image */}
+      <div style={sectionStyle}>
+        <h3 style={{ fontSize: 13, fontWeight: 600, marginBottom: 12, color: "var(--text-primary)" }}>
+          {t("settings.vmImage")}
+        </h3>
+        {vmList.length === 0 ? (
+          <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
+            {t("settings.vmImageNoVm")}
+          </div>
+        ) : (
+          vmList.map((vm) => (
+            <div
+              key={vm.id}
+              style={{
+                background: "var(--bg-elevated)",
+                borderRadius: 6,
+                padding: "10px 12px",
+                marginBottom: 8,
+              }}
+            >
+              <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text-primary)", marginBottom: 6 }}>
+                {vm.name}
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "120px 1fr", rowGap: 4 }}>
+                <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{t("settings.vmImageManifestVersion")}</span>
+                <span style={{ fontSize: 11, color: "var(--text-primary)", fontFamily: "var(--font-mono)" }}>
+                  {vm.manifest_version ?? "—"}
+                </span>
+                <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{t("settings.vmImageOsVersion")}</span>
+                <span style={{ fontSize: 11, color: "var(--text-primary)", fontFamily: "var(--font-mono)" }}>
+                  {vm.base_os_version ?? "—"}
+                </span>
+                <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{t("settings.vmImageBaseOs")}</span>
+                <span style={{ fontSize: 11, color: "var(--text-primary)", fontFamily: "var(--font-mono)" }}>
+                  {vm.base_os ?? "—"}
+                </span>
+                <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{t("settings.vmImageInstalledAt")}</span>
+                <span style={{ fontSize: 11, color: "var(--text-primary)" }}>
+                  {vm.created_at ? vm.created_at.slice(0, 10) : "—"}
+                </span>
+              </div>
+            </div>
+          ))
+        )}
       </div>
 
     </div>

--- a/apps/nilbox/src/i18n/locales/en.ts
+++ b/apps/nilbox/src/i18n/locales/en.ts
@@ -463,6 +463,12 @@ const en = {
     sidebarDisplayDesc: "Choose how the sidebar menu is displayed",
     sidebarIconOnly: "Icon only",
     sidebarIconText: "Icon + Text",
+    vmImage: "VM Image",
+    vmImageManifestVersion: "Nilbox OS Ver.",
+    vmImageOsVersion: "OS Version",
+    vmImageBaseOs: "Base OS",
+    vmImageInstalledAt: "Installed",
+    vmImageNoVm: "No VM image installed",
   },
   guide: {
     scenarioListTitle: "Tutorials",

--- a/apps/nilbox/src/i18n/locales/ko.ts
+++ b/apps/nilbox/src/i18n/locales/ko.ts
@@ -462,6 +462,12 @@ const ko = {
     sidebarDisplayDesc: "사이드바 메뉴 표시 방식을 선택합니다",
     sidebarIconOnly: "아이콘만",
     sidebarIconText: "아이콘 + 텍스트",
+    vmImage: "VM 이미지",
+    vmImageManifestVersion: "Nilbox OS 버전",
+    vmImageOsVersion: "OS 버전",
+    vmImageBaseOs: "기반 OS",
+    vmImageInstalledAt: "설치일",
+    vmImageNoVm: "설치된 VM 이미지가 없습니다",
   },
   guide: {
     scenarioListTitle: "튜토리얼",

--- a/apps/nilbox/src/lib/tauri.ts
+++ b/apps/nilbox/src/lib/tauri.ts
@@ -21,6 +21,7 @@ export interface VmInfo {
   base_os: string | null;
   base_os_version: string | null;
   target_platform: string | null;
+  manifest_version: string | null;
   admin_urls: AdminUrlInfo[];
   vm_dir: string | null;
 }

--- a/crates/nilbox-core/src/config_store.rs
+++ b/crates/nilbox-core/src/config_store.rs
@@ -35,6 +35,7 @@ pub struct VmRecord {
     pub base_os: Option<String>,
     pub base_os_version: Option<String>,
     pub target_platform: Option<String>,
+    pub manifest_version: Option<String>,
 }
 
 /// An admin URL entry for a VM.
@@ -745,6 +746,20 @@ impl ConfigStore {
             )?;
         }
 
+        // v40: add manifest_version to vms table.
+        if current_version > 0 && current_version < 40 {
+            let has_manifest_version: bool = conn.query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('vms') WHERE name='manifest_version'",
+                [], |r| r.get::<_, i64>(0),
+            ).map(|n| n > 0).unwrap_or(false);
+            if !has_manifest_version {
+                conn.execute_batch(
+                    "ALTER TABLE vms ADD COLUMN manifest_version TEXT;"
+                )?;
+            }
+            conn.execute("INSERT INTO schema_version (version) VALUES (40)", [])?;
+        }
+
         // v39: add inspect_mode + is_system to domain_allowlist for TLS-inspect bypass management.
         if current_version > 0 && current_version < 39 {
             // ALTER TABLE is idempotent-ish via column existence check.
@@ -794,8 +809,8 @@ impl ConfigStore {
     pub fn insert_vm(&self, record: &VmRecord, admin_urls: &[(String, String)]) -> Result<String> {
         let conn = self.conn.lock().map_err(|_| anyhow!("DB lock poisoned"))?;
         conn.execute(
-            "INSERT INTO vms (id, name, disk_image, kernel, initrd, append, memory_mb, cpus, is_default, description, last_boot_at, admin_url, admin_label, base_os, base_os_version, target_platform)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+            "INSERT INTO vms (id, name, disk_image, kernel, initrd, append, memory_mb, cpus, is_default, description, last_boot_at, admin_url, admin_label, base_os, base_os_version, target_platform, manifest_version)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
             params![
                 record.id,
                 record.name,
@@ -813,6 +828,7 @@ impl ConfigStore {
                 record.base_os,
                 record.base_os_version,
                 record.target_platform,
+                record.manifest_version,
             ],
         ).context("Failed to insert VM")?;
         let created_at: String = conn.query_row(
@@ -870,7 +886,7 @@ impl ConfigStore {
         let mut stmt = conn.prepare(
             "SELECT id, name, disk_image, kernel, initrd, append, memory_mb, cpus, is_default,
                     description, last_boot_at, strftime('%Y-%m-%dT%H:%M:%SZ', created_at),
-                    admin_url, admin_label, base_os, base_os_version, target_platform
+                    admin_url, admin_label, base_os, base_os_version, target_platform, manifest_version
              FROM vms WHERE id = ?1"
         )?;
         let result = stmt.query_row(params![id], |row| {
@@ -892,6 +908,7 @@ impl ConfigStore {
                 base_os: row.get(14)?,
                 base_os_version: row.get(15)?,
                 target_platform: row.get(16)?,
+                manifest_version: row.get(17)?,
             })
         });
         match result {
@@ -906,7 +923,7 @@ impl ConfigStore {
         let mut stmt = conn.prepare(
             "SELECT id, name, disk_image, kernel, initrd, append, memory_mb, cpus, is_default,
                     description, last_boot_at, strftime('%Y-%m-%dT%H:%M:%SZ', created_at),
-                    admin_url, admin_label, base_os, base_os_version, target_platform
+                    admin_url, admin_label, base_os, base_os_version, target_platform, manifest_version
              FROM vms ORDER BY created_at"
         )?;
         let rows = stmt.query_map([], |row| {
@@ -928,6 +945,7 @@ impl ConfigStore {
                 base_os: row.get(14)?,
                 base_os_version: row.get(15)?,
                 target_platform: row.get(16)?,
+                manifest_version: row.get(17)?,
             })
         })?;
         rows.collect::<std::result::Result<Vec<_>, _>>().map_err(Into::into)
@@ -938,7 +956,7 @@ impl ConfigStore {
         let mut stmt = conn.prepare(
             "SELECT id, name, disk_image, kernel, initrd, append, memory_mb, cpus, is_default,
                     description, last_boot_at, strftime('%Y-%m-%dT%H:%M:%SZ', created_at),
-                    admin_url, admin_label, base_os, base_os_version, target_platform
+                    admin_url, admin_label, base_os, base_os_version, target_platform, manifest_version
              FROM vms WHERE is_default = 1 LIMIT 1"
         )?;
         let result = stmt.query_row([], |row| {
@@ -960,6 +978,7 @@ impl ConfigStore {
                 base_os: row.get(14)?,
                 base_os_version: row.get(15)?,
                 target_platform: row.get(16)?,
+                manifest_version: row.get(17)?,
             })
         });
         match result {

--- a/crates/nilbox-core/src/service.rs
+++ b/crates/nilbox-core/src/service.rs
@@ -313,6 +313,7 @@ impl NilBoxService {
             base_os: record.base_os.clone(),
             base_os_version: record.base_os_version.clone(),
             target_platform: record.target_platform.clone(),
+            manifest_version: record.manifest_version.clone(),
             admin_urls: RwLock::new(
                 self.state.config_store.list_vm_admin_urls(&id).unwrap_or_else(|e| {
                     warn!("Failed to load admin URLs for VM {}: {}", id, e);
@@ -365,6 +366,7 @@ impl NilBoxService {
             base_os: None,
             base_os_version: None,
             target_platform: None,
+            manifest_version: None,
         };
         let created_at = self.state.config_store.insert_vm(&record, &[])?;
         self.state.config_store.set_default_vm(&id)?;
@@ -389,6 +391,7 @@ impl NilBoxService {
             base_os: None,
             base_os_version: None,
             target_platform: None,
+            manifest_version: None,
             admin_urls: RwLock::new(vec![]),
             platform: RwLock::new(platform),
             multiplexer: RwLock::new(None),
@@ -797,6 +800,7 @@ impl NilBoxService {
                     base_os: vm.base_os.clone(),
                     base_os_version: vm.base_os_version.clone(),
                     target_platform: vm.target_platform.clone(),
+                    manifest_version: vm.manifest_version.clone(),
                     admin_urls: admin_urls.clone(),
                     vm_dir,
                 }

--- a/crates/nilbox-core/src/state.rs
+++ b/crates/nilbox-core/src/state.rs
@@ -49,6 +49,7 @@ pub struct VmInstance {
     pub base_os: Option<String>,
     pub base_os_version: Option<String>,
     pub target_platform: Option<String>,
+    pub manifest_version: Option<String>,
     pub admin_urls: RwLock<Vec<AdminUrlRecord>>,
     pub platform: RwLock<Box<dyn VmPlatform>>,
     pub multiplexer: RwLock<Option<Arc<StreamMultiplexer>>>,
@@ -82,6 +83,7 @@ pub struct VmInfo {
     pub base_os: Option<String>,
     pub base_os_version: Option<String>,
     pub target_platform: Option<String>,
+    pub manifest_version: Option<String>,
     pub admin_urls: Vec<AdminUrlRecord>,
     /// VM storage directory (parent of disk image).
     pub vm_dir: Option<String>,

--- a/crates/nilbox-core/src/vm_install.rs
+++ b/crates/nilbox-core/src/vm_install.rs
@@ -399,6 +399,7 @@ pub async fn install_from_manifest_url(
         base_os: manifest.base_os.clone(),
         base_os_version: manifest.base_os_version.clone(),
         target_platform: manifest.target_platform.as_ref().map(|v| v.join(",")),
+        manifest_version: manifest.version.clone(),
     };
 
     let admin_urls: Vec<(String, String)> = manifest
@@ -565,6 +566,7 @@ pub fn install_from_cache(
         base_os: manifest.base_os.clone(),
         base_os_version: manifest.base_os_version.clone(),
         target_platform: manifest.target_platform.as_ref().map(|v| v.join(",")),
+        manifest_version: manifest.version.clone(),
     };
 
     let admin_urls: Vec<(String, String)> = manifest


### PR DESCRIPTION
## Summary

Closes #20

- Add `manifest_version` column to `vms` table via schema migration v40
- Persist manifest `version` field from store manifest during VM install
- Expose `manifest_version` in `VmInfo` returned by `list_vms`
- Show **Nilbox OS Ver.** and **OS Version** as separate rows in the Settings VM Image section
- Move VM Image section to the bottom of Settings screen (below Developer Settings)
- Add i18n keys for VM image info (en/ko)

## Changes

| Layer | File | Change |
|---|---|---|
| DB | `config_store.rs` | `manifest_version TEXT` column + migration v40 + CRUD queries |
| Core | `state.rs`, `service.rs` | `manifest_version` field in `VmInstance` / `VmInfo` |
| Install | `vm_install.rs` | Save `manifest.version` → `VmRecord.manifest_version` |
| API | `tauri.ts` | `manifest_version: string \| null` in `VmInfo` interface |
| UI | `Settings.tsx` | VM Image section with two separate version rows |
| i18n | `en.ts`, `ko.ts` | New keys: `vmImageManifestVersion`, `vmImageOsVersion`, etc. |

## Test plan

- [x] Install a VM from the Store and open Settings — verify Nilbox OS Ver. and OS Version are displayed
- [x] Existing DB (pre-migration) upgrades cleanly with the new `manifest_version` column
- [x] VM with no manifest version shows `—` in Nilbox OS Ver. row
- [x] VM Image section appears at the bottom of Settings, after Developer Settings
- [x] Labels render correctly in both English and Korean