### PR TITLE
Fix release shell vim rendering

### DIFF
--- a/apps/nilbox/src-tauri/entitlements.plist
+++ b/apps/nilbox/src-tauri/entitlements.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" ...>
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.cs.allow-jit</key><false/>
+    <key>com.apple.security.cs.allow-jit</key><true/>
     <key>com.apple.security.network.client</key><true/>
     <key>com.apple.security.network.server</key><true/>
     <key>com.apple.security.virtualization</key><true/>

--- a/apps/nilbox/vite.config.ts
+++ b/apps/nilbox/vite.config.ts
@@ -3,11 +3,28 @@ import react from "@vitejs/plugin-react";
 import checker from "vite-plugin-checker";
 
 const host = process.env.TAURI_DEV_HOST;
+const xtermRequestModeEnum =
+  'let r;(P=>(P[P.NOT_RECOGNIZED=0]="NOT_RECOGNIZED",P[P.SET=1]="SET",P[P.RESET=2]="RESET",P[P.PERMANENTLY_SET=3]="PERMANENTLY_SET",P[P.PERMANENTLY_RESET=4]="PERMANENTLY_RESET"))(r||={});';
+const xtermRequestModeEnumSafe =
+  "const r={NOT_RECOGNIZED:0,SET:1,RESET:2,PERMANENTLY_SET:3,PERMANENTLY_RESET:4};";
 
 export default defineConfig(async () => ({
-  plugins: [react(), checker({ typescript: true })],
+  plugins: [
+    {
+      name: "patch-xterm-request-mode-enum",
+      enforce: "pre",
+      transform(code, id) {
+        if (!id.includes("@xterm/xterm/lib/xterm.mjs")) return null;
+        if (!code.includes(xtermRequestModeEnum)) return null;
+        return code.replace(xtermRequestModeEnum, xtermRequestModeEnumSafe);
+      },
+    },
+    react(),
+    checker({ typescript: true }),
+  ],
   clearScreen: false,
   build: {
+    target: "safari13",
     chunkSizeWarningLimit: 1000,
   },
   server: {


### PR DESCRIPTION
## Summary
- Patch the xterm.js requestMode enum initialization before Vite production bundling to avoid a release-only runtime ReferenceError in WKWebView.
- Enable the macOS allow-jit entitlement so JavaScriptCore can use JIT fast paths under Hardened Runtime.

## Validation
- npm run build
- plutil -lint apps/nilbox/src-tauri/entitlements.plist
- Verified the production bundle no longer contains the broken requestMode r reference pattern.