### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,7 +3470,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nilbox"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "nilbox-blocklist"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "nilbox-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "nilbox-mcp-bridge"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "GPL-3.0-or-later"
 

--- a/apps/nilbox/src-tauri/src/main.rs
+++ b/apps/nilbox/src-tauri/src/main.rs
@@ -151,10 +151,15 @@ fn main() {
     // Required for reqwest 0.12 with rustls-tls-manual-roots.
     let _ = rustls::crypto::ring::default_provider().install_default();
 
+    let default_filter = if cfg!(debug_assertions) {
+        "nilbox=debug,nilbox_core=debug"
+    } else {
+        "nilbox=info,nilbox_core=info"
+    };
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "nilbox=debug,nilbox_core=debug".into()),
+                .unwrap_or_else(|_| default_filter.into()),
         )
         .init();
 

--- a/apps/nilbox/src-tauri/tauri.conf.json
+++ b/apps/nilbox/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "nilbox",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "run.nilbox.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bump workspace version 0.2.1 → 0.2.2 (Cargo.toml, tauri.conf.json, Cargo.lock)
- Drop default tracing filter to `info` for release builds (`debug_assertions` off); keeps `debug` for dev. `RUST_LOG` env var still overrides.

Closes #24

## Changes since 0.2.1
- feat: display VM image version info in Settings (#20, #21)
- fix: vim rendering in release shell (#23)
- fix: auto-refresh store access token on expiry and 401 (#19)
- fix: prevent certutil -N hang on existing NSS DB in VM image builds (#16)

## Test plan
- [ ] `cargo build --release` succeeds
- [ ] Release binary does not emit DEBUG logs by default
- [ ] `RUST_LOG=nilbox=debug` still enables debug logs in release
- [ ] Dev build (`cargo run`) still shows debug logs