### PR TITLE
fix: daily usage stats show "No usage data" due to UTC/local timezone mismatch

### DIFF
--- a/crates/nilbox-core/src/config_store.rs
+++ b/crates/nilbox-core/src/config_store.rs
@@ -2328,7 +2328,7 @@ impl ConfigStore {
                     SUM(request_tokens), SUM(response_tokens),
                     SUM(total_tokens), COUNT(*)
              FROM token_usage_logs
-             WHERE vm_id = ?1 AND created_at LIKE ?2
+             WHERE vm_id = ?1 AND DATE(created_at, 'localtime') LIKE ?2
              GROUP BY provider_id
              ORDER BY SUM(total_tokens) DESC"
         )?;
@@ -2388,11 +2388,11 @@ impl ConfigStore {
     ) -> Result<Vec<TokenUsageDateEntry>> {
         let conn = self.conn.lock().map_err(|_| anyhow!("DB lock poisoned"))?;
         let mut stmt = conn.prepare(
-            "SELECT DATE(created_at) as date, provider_id,
+            "SELECT DATE(created_at, 'localtime') as date, provider_id,
                     SUM(total_tokens), COUNT(*)
              FROM token_usage_logs
-             WHERE vm_id = ?1 AND DATE(created_at) >= ?2 AND DATE(created_at) <= ?3
-             GROUP BY DATE(created_at), provider_id
+             WHERE vm_id = ?1 AND DATE(created_at, 'localtime') >= ?2 AND DATE(created_at, 'localtime') <= ?3
+             GROUP BY DATE(created_at, 'localtime'), provider_id
              ORDER BY date ASC, provider_id"
         )?;
         let rows = stmt.query_map(params![vm_id, from_date, to_date], |row| {


### PR DESCRIPTION
## Summary

- `token_usage_logs.created_at` is stored in UTC via `datetime('now')`, but date-range queries used `DATE(created_at)` which extracts the UTC date
- Query parameters are local-time dates from `Local::now().date_naive()`, causing a mismatch for UTC+ timezone users
- In KST (UTC+9), requests made between midnight–09:00 local time have a UTC date of the previous day → excluded from the daily chart → "No usage data" shown incorrectly

## Fix

Replace `DATE(created_at)` with `DATE(created_at, 'localtime')` in two queries in `config_store.rs`:
- `get_token_usage_date_range` — used by the daily chart for today's real-time data
- `get_token_usage_daily` — used for per-day aggregation from raw logs

## Test plan

- [x] Make API requests and verify they appear in the daily chart (especially requests made in early morning local time)
- [x] Verify daily chart data is correct across timezone boundaries
- [x] Confirm "No usage data" no longer appears when requests exist for the current day

Closes #27

Signed-off-by: Steven Hong <64390350+rednakta@users.noreply.github.com>