### PR TITLE
fix: forward CJK IME insertReplacementText events to shell

### DIFF
--- a/apps/nilbox/src/components/screens/Shell.tsx
+++ b/apps/nilbox/src/components/screens/Shell.tsx
@@ -38,6 +38,52 @@ const createTerminal = () =>
     cursorBlink: true,
   });
 
+// Workaround for issue #31: macOS WKWebView (wry/tao) does not route CJK IME
+// input through the marked-text protocol on Apple Silicon, so xterm.js never
+// sees `composition*` events. Each syllable update arrives as a `beforeinput`
+// of inputType `insertReplacementText`, which xterm drops because it only
+// forwards `insertText`. Result: only the first jamo of every Hangul syllable
+// reaches the remote shell. We mirror what `setMarkedText:` would have done by
+// emitting DEL bytes for the previous insertion plus the new replacement text.
+const setupCjkImeWorkaround = (
+  textarea: HTMLTextAreaElement,
+  getSessionId: () => number | undefined,
+): (() => void) => {
+  let lastInserted = "";
+  const reset = () => {
+    lastInserted = "";
+  };
+
+  const onBeforeInput = (event: Event) => {
+    const e = event as InputEvent;
+    const data = e.data ?? "";
+    if (e.inputType === "insertReplacementText" && data) {
+      const sessionId = getSessionId();
+      if (sessionId == null) {
+        lastInserted = data;
+        return;
+      }
+      const eraseCount = [...lastInserted].length;
+      const payload = "\x7f".repeat(eraseCount) + data;
+      const bytes = Array.from(new TextEncoder().encode(payload));
+      writeShell(sessionId, bytes).catch(() => {});
+      lastInserted = data;
+    } else if (e.inputType === "insertText" && data) {
+      lastInserted = data;
+    } else {
+      reset();
+    }
+  };
+
+  textarea.addEventListener("beforeinput", onBeforeInput);
+  textarea.addEventListener("blur", reset);
+
+  return () => {
+    textarea.removeEventListener("beforeinput", onBeforeInput);
+    textarea.removeEventListener("blur", reset);
+  };
+};
+
 export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onInstallUrlConsumed, verifyInstallUuid, onNavigate }) => {
   const { t } = useTranslation();
   const [tabs, setTabs] = useState<TabInfo[]>([{ id: 1, connected: false, label: t("shell.defaultTabLabel", { n: "1" }) }]);
@@ -62,6 +108,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
     closedUnlisten?: UnlistenFn;
     resizeObserver?: ResizeObserver;
     sessionId?: number;
+    imeCleanup?: () => void;
   }>>(new Map());
 
   const getOrCreateTerm = (tabId: number) => {
@@ -81,6 +128,12 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
     if (div) {
       if (!entry.term.element) {
         entry.term.open(div);
+        const textarea = div.querySelector<HTMLTextAreaElement>(
+          "textarea.xterm-helper-textarea"
+        );
+        if (textarea && !entry.imeCleanup) {
+          entry.imeCleanup = setupCjkImeWorkaround(textarea, () => entry.sessionId);
+        }
       } else if (!div.contains(entry.term.element)) {
         // Re-attach existing terminal to the new container
         div.appendChild(entry.term.element);
@@ -213,6 +266,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
       entry.unlisten?.();
       entry.closedUnlisten?.();
       entry.resizeObserver?.disconnect();
+      entry.imeCleanup?.();
       entry.term.dispose();
       termRefs.current.delete(tabId);
     }
@@ -368,6 +422,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
           entry.unlisten?.();
           entry.closedUnlisten?.();
           entry.resizeObserver?.disconnect();
+          entry.imeCleanup?.();
           entry.term.dispose();
         }
       }


### PR DESCRIPTION
Fixes #31.

## Summary

On macOS WKWebView (wry/tao on Apple Silicon), CJK IMEs do not use the
`setMarkedText:` marked-text protocol, so xterm.js never sees
`compositionstart` / `compositionupdate` / `compositionend` events. Instead,
each syllable update arrives as a `beforeinput` of inputType
`insertReplacementText`, which xterm.js drops because its `_inputEvent`
handler only forwards `insertText`. The user-visible symptom is that typing
`gksrmf` in 2-set Korean produces `ㅎㄱ` at the remote shell instead of
`한글` — only the first jamo of every Hangul syllable survives.

This PR adds a small client-side workaround in `Shell.tsx` that mirrors what
the marked-text path would have produced.

## Root cause (recap of #31)

Per the diagnostic trace in the issue, the same `beforeinput` sequence fires
on both xterm's helper textarea and on an arbitrary visible `<textarea>`,
which rules out xterm's helper positioning as the trigger:

```
'g' → insertText            data="ㅎ"  isComposing=false
'k' → insertReplacementText data="하"  isComposing=false
's' → insertReplacementText data="한"  isComposing=false
'g' → insertText            data="ㄱ"  isComposing=false   ← syllable boundary
'm' → insertReplacementText data="그"
'f' → insertReplacementText data="글"
```

The leading consonant of each syllable arrives as `insertText` (forwarded by
xterm), every subsequent in-syllable update arrives as
`insertReplacementText` (dropped by xterm). macOS is using direct
insertion-with-replacement instead of the marked-text protocol that would
fire `composition*`.

## Why a client-side workaround

The issue raised the open question of fixing this at the wry/tao/WebKit
layer vs. at the app layer. This PR takes the app-layer route because:

1. It unblocks current users on shipped Tauri/wry versions without waiting
   for an upstream fix.
2. It is self-contained — ~50 lines in `Shell.tsx`, no dependency bumps.
3. It is harmless on platforms where the marked-text protocol works
   correctly: those platforms emit `insertText` only, so the
   `insertReplacementText` branch never runs.

A proper upstream fix in wry's input-context wiring is still desirable and
this PR does not preclude it.

## How the fix works

A single `beforeinput` listener is attached to xterm's helper textarea once
per terminal, right after `term.open(div)` in `mountTerminal`:

- **`insertText`**: just record the inserted text. xterm already forwards
  this to the shell, so we don't write anything ourselves.
- **`insertReplacementText`**: emit `\x7f` (DEL) repeated for the previous
  insertion's *code-point* length, followed by the new replacement text,
  via `writeShell`. This is the byte sequence the marked-text path would
  have produced — readline binds `\x7f` to `backward-delete-char`, so the
  remote shell erases the previous syllable and renders the new one.
- **anything else, or `blur`**: reset the tracked previous insertion.

Because `insertText` always overwrites the tracking state, transitioning
between syllables (the `'g'` at byte 4 above) is handled naturally without
needing to detect syllable boundaries explicitly.

## Lifecycle

The listener is created exactly once per terminal in `mountTerminal` and
torn down alongside `term.dispose()` in:

- `closeTab` (single-tab close)
- the unmount `useEffect` that closes all cached sessions across all VMs

Switching VMs keeps terminals alive (only listeners are torn down on the
data path), so the IME listener is intentionally **not** disposed in that
flow — it stays bound to the textarea for the lifetime of the terminal.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] macOS Apple Silicon (Sequoia), 2-set Korean: `gksrmf` → `한글`
- [ ] macOS Apple Silicon, English typing unaffected (no extra DELs)
- [ ] Backspace, Enter, Tab, arrow keys still work as before
- [ ] Multiple shell tabs: each tab handles IME independently
- [ ] VM switch (sessions stay alive): IME still works after switching back
- [ ] Close tab → no leaked listeners (entry.imeCleanup runs)

## Notes / non-goals

- Uses `\x7f` (DEL) not `\x08` (BS) because that's what xterm.js itself
  sends for the Backspace key and what readline binds to erase.
- Code-point counting via `[...lastInserted].length` handles surrogate
  pairs; Hangul/CJK syllables are BMP in practice but this is correct for
  any future emoji-bearing IME data too.
- The autocorrect path could in theory also produce
  `insertReplacementText` with a multi-character target range, but xterm's
  helper textarea has `autocorrect="off"` so this is not exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)