### PR TITLE
fix: prevent space and ASCII key duplication in shell

### DIFF
--- a/apps/nilbox/src/components/screens/Shell.tsx
+++ b/apps/nilbox/src/components/screens/Shell.tsx
@@ -66,22 +66,21 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
   }>>(new Map());
 
   /**
-   * macOS WKWebView under Tauri (observed on Apple Silicon, Sequoia) does not
-   * deliver setMarkedText: through the DOM composition events. The Korean
-   * 2-set IME instead grows each syllable by repeated insertText:replacementRange:
-   * calls — WebKit relays these as `inputType: "insertReplacementText"`
-   * without firing compositionstart/update/end. xterm's _inputEvent only acts
-   * on `inputType === "insertText"`, so every replacement (i.e. everything
-   * after the very first jamo of each syllable) is silently dropped, and the
-   * shell receives only the leading consonant per syllable.
+   * macOS WKWebView under Tauri does not fire DOM composition events for
+   * Korean IME — each jamo arrives as plain `input` (insertText for the first
+   * jamo of a syllable, insertReplacementText as the syllable grows, and
+   * insertText again when the next syllable begins on top of the previous
+   * one). xterm's own `_inputEvent` either skips these (when _keyDownSeen is
+   * true and ev.composed is true) or duplicates them (when ev.composed is
+   * false), and the behavior varies per event.
    *
-   * The shim listens on term.element in capture phase (which fires before
-   * xterm's textarea-bound handler) and, when an insertReplacementText event
-   * arrives, computes the diff between the textarea value and what we last
-   * forwarded, then forwards `\x7f`*erase + newchars through term.input so
-   * xterm's onData → writeShell pipeline carries it to the shell unchanged.
-   * For insertText we leave xterm in charge and just track the new state.
-   * State is reset whenever xterm clears the textarea (Enter, Ctrl+C, blur).
+   * The shim attaches in capture phase on term.element so it runs before
+   * xterm's textarea handler. It mirrors textarea.value and forwards
+   * `\x7f`*erase + newchars through term.input. After handling we call
+   * stopPropagation so xterm's listener never runs for the same event,
+   * eliminating the duplicate-send path. ASCII typing is sent by xterm's
+   * keypress handler (separate event), which sets _keyPressHandled — when we
+   * see that flag we just track state without re-sending.
    */
   const attachImeShim = (entry: TermEntry) => {
     if (entry.imeShimCleanup) return;
@@ -94,22 +93,21 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
 
     const onInput = (event: Event) => {
       if (event.target !== textarea) return;
-      const ev = event as InputEvent;
       const cur = textarea.value;
-      if (ev.inputType === "insertReplacementText") {
-        let common = 0;
-        const max = Math.min(lastSent.length, cur.length);
-        while (common < max && lastSent.charCodeAt(common) === cur.charCodeAt(common)) common++;
-        const erase = lastSent.length - common;
-        const insert = cur.substring(common);
-        if (erase > 0 || insert.length > 0) {
-          term.input("\x7f".repeat(erase) + insert, true);
-        }
+      if ((term as unknown as { _keyPressHandled: boolean })._keyPressHandled) {
         lastSent = cur;
-        ev.stopPropagation();
-      } else {
-        lastSent = cur;
+        return;
       }
+      let common = 0;
+      const max = Math.min(lastSent.length, cur.length);
+      while (common < max && lastSent.charCodeAt(common) === cur.charCodeAt(common)) common++;
+      const erase = lastSent.length - common;
+      const insert = cur.substring(common);
+      if (erase > 0 || insert.length > 0) {
+        term.input("\x7f".repeat(erase) + insert, true);
+      }
+      lastSent = cur;
+      event.stopPropagation();
     };
 
     const onBlur = () => { lastSent = ""; };

--- a/apps/nilbox/src/components/screens/Shell.tsx
+++ b/apps/nilbox/src/components/screens/Shell.tsx
@@ -62,7 +62,74 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
     closedUnlisten?: UnlistenFn;
     resizeObserver?: ResizeObserver;
     sessionId?: number;
+    imeShimCleanup?: () => void;
   }>>(new Map());
+
+  /**
+   * macOS WKWebView under Tauri (observed on Apple Silicon, Sequoia) does not
+   * deliver setMarkedText: through the DOM composition events. The Korean
+   * 2-set IME instead grows each syllable by repeated insertText:replacementRange:
+   * calls — WebKit relays these as `inputType: "insertReplacementText"`
+   * without firing compositionstart/update/end. xterm's _inputEvent only acts
+   * on `inputType === "insertText"`, so every replacement (i.e. everything
+   * after the very first jamo of each syllable) is silently dropped, and the
+   * shell receives only the leading consonant per syllable.
+   *
+   * The shim listens on term.element in capture phase (which fires before
+   * xterm's textarea-bound handler) and, when an insertReplacementText event
+   * arrives, computes the diff between the textarea value and what we last
+   * forwarded, then forwards `\x7f`*erase + newchars through term.input so
+   * xterm's onData → writeShell pipeline carries it to the shell unchanged.
+   * For insertText we leave xterm in charge and just track the new state.
+   * State is reset whenever xterm clears the textarea (Enter, Ctrl+C, blur).
+   */
+  const attachImeShim = (entry: TermEntry) => {
+    if (entry.imeShimCleanup) return;
+    const term = entry.term;
+    const textarea = term.textarea;
+    const root = term.element;
+    if (!textarea || !root) return;
+
+    let lastSent = "";
+
+    const onInput = (event: Event) => {
+      if (event.target !== textarea) return;
+      const ev = event as InputEvent;
+      const cur = textarea.value;
+      if (ev.inputType === "insertReplacementText") {
+        let common = 0;
+        const max = Math.min(lastSent.length, cur.length);
+        while (common < max && lastSent.charCodeAt(common) === cur.charCodeAt(common)) common++;
+        const erase = lastSent.length - common;
+        const insert = cur.substring(common);
+        if (erase > 0 || insert.length > 0) {
+          term.input("\x7f".repeat(erase) + insert, true);
+        }
+        lastSent = cur;
+        ev.stopPropagation();
+      } else {
+        lastSent = cur;
+      }
+    };
+
+    const onBlur = () => { lastSent = ""; };
+    const onKeyDown = (ev: KeyboardEvent) => {
+      if (ev.key === "Enter" || (ev.ctrlKey && (ev.key === "c" || ev.key === "C"))) {
+        queueMicrotask(() => { lastSent = textarea.value; });
+      }
+    };
+
+    root.addEventListener("input", onInput, true);
+    textarea.addEventListener("blur", onBlur);
+    textarea.addEventListener("keydown", onKeyDown);
+
+    entry.imeShimCleanup = () => {
+      root.removeEventListener("input", onInput, true);
+      textarea.removeEventListener("blur", onBlur);
+      textarea.removeEventListener("keydown", onKeyDown);
+      entry.imeShimCleanup = undefined;
+    };
+  };
 
   const getOrCreateTerm = (tabId: number) => {
     if (!termRefs.current.has(tabId)) {
@@ -85,6 +152,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
         // Re-attach existing terminal to the new container
         div.appendChild(entry.term.element);
       }
+      attachImeShim(entry);
       entry.fit.fit();
     }
   };
@@ -210,6 +278,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
     const entry = termRefs.current.get(tabId);
     if (entry) {
       entry.onDataDisposable?.dispose();
+      entry.imeShimCleanup?.();
       entry.unlisten?.();
       entry.closedUnlisten?.();
       entry.resizeObserver?.disconnect();
@@ -365,6 +434,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
             closeShell(entry.sessionId).catch(() => {});
           }
           entry.onDataDisposable?.dispose();
+          entry.imeShimCleanup?.();
           entry.unlisten?.();
           entry.closedUnlisten?.();
           entry.resizeObserver?.disconnect();

--- a/apps/nilbox/src/components/screens/Shell.tsx
+++ b/apps/nilbox/src/components/screens/Shell.tsx
@@ -78,9 +78,16 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
    * xterm's textarea handler. It mirrors textarea.value and forwards
    * `\x7f`*erase + newchars through term.input. After handling we call
    * stopPropagation so xterm's listener never runs for the same event,
-   * eliminating the duplicate-send path. ASCII typing is sent by xterm's
-   * keypress handler (separate event), which sets _keyPressHandled — when we
-   * see that flag we just track state without re-sending.
+   * eliminating the duplicate-send path.
+   *
+   * For non-IME ASCII keystrokes, xterm has already sent the character via
+   * its keydown handler (space, digits, symbols, lowercase a-z) or keypress
+   * handler (uppercase A-Z, sets _keyPressHandled). On WKWebView the
+   * preventDefault doesn't stop the textarea from receiving the char, so an
+   * input event still fires. We detect those keystrokes via a keydown flag
+   * and just sync state without re-sending. IME keystrokes on WKWebView fire
+   * keydown with keyCode=229 / key="Process", which we leave unflagged so
+   * the diff path runs.
    */
   const attachImeShim = (entry: TermEntry) => {
     if (entry.imeShimCleanup) return;
@@ -90,12 +97,15 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
     if (!textarea || !root) return;
 
     let lastSent = "";
+    let xtermHandledKey = false;
 
     const onInput = (event: Event) => {
       if (event.target !== textarea) return;
       const cur = textarea.value;
-      if ((term as unknown as { _keyPressHandled: boolean })._keyPressHandled) {
+      if (xtermHandledKey || (term as unknown as { _keyPressHandled: boolean })._keyPressHandled) {
         lastSent = cur;
+        xtermHandledKey = false;
+        event.stopPropagation();
         return;
       }
       let common = 0;
@@ -110,8 +120,15 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
       event.stopPropagation();
     };
 
-    const onBlur = () => { lastSent = ""; };
+    const onBlur = () => { lastSent = ""; xtermHandledKey = false; };
     const onKeyDown = (ev: KeyboardEvent) => {
+      const isImeKey = ev.keyCode === 229 || ev.key === "Process" || ev.isComposing;
+      xtermHandledKey =
+        !isImeKey &&
+        ev.key.length === 1 &&
+        !ev.ctrlKey &&
+        !ev.metaKey &&
+        !ev.altKey;
       if (ev.key === "Enter" || (ev.ctrlKey && (ev.key === "c" || ev.key === "C"))) {
         queueMicrotask(() => { lastSent = textarea.value; });
       }


### PR DESCRIPTION
## Summary

Fixes duplicate space and ASCII character input in the shell on macOS WKWebView.

The IME shim added in #31 correctly handles Korean Hangul composition but had a side effect: it duplicates non-IME ASCII keystrokes like space, lowercase letters, digits, and symbols. This is because:

1. xterm's `keydown` handler sends these characters via `triggerDataEvent` and calls `preventDefault`
2. On macOS WKWebView, `preventDefault` doesn't stop the textarea from receiving the character
3. An `input` event fires, and the IME shim (which only checked `_keyPressHandled` for uppercase A-Z) would send the character again

## Solution

Track whether a keydown event was for a non-IME ASCII character. If so, the subsequent input event is a synthetic duplication from WKWebView — just sync state and skip re-sending.

IME keystrokes (detected via `keyCode=229` / `key="Process"` / `isComposing`) bypass this flag so the Hangul diff path still handles composition correctly.

## Testing

- Pressing space in shell no longer adds duplicate spaces
- Regular ASCII typing works normally
- Korean Hangul input continues to work via the composition diff path