### PR TITLE
fix: renumber shell tabs after closing one (#33)

### DIFF
--- a/apps/nilbox/src/components/screens/Shell.tsx
+++ b/apps/nilbox/src/components/screens/Shell.tsx
@@ -20,7 +20,7 @@ interface Props {
 interface TabInfo {
   id: number;
   connected: boolean;
-  label: string;
+  customLabel?: string;
   sessionId?: number;
 }
 
@@ -40,7 +40,7 @@ const createTerminal = () =>
 
 export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onInstallUrlConsumed, verifyInstallUuid, onNavigate }) => {
   const { t } = useTranslation();
-  const [tabs, setTabs] = useState<TabInfo[]>([{ id: 1, connected: false, label: t("shell.defaultTabLabel", { n: "1" }) }]);
+  const [tabs, setTabs] = useState<TabInfo[]>([{ id: 1, connected: false }]);
   const [activeTab, setActiveTab] = useState(1);
   const [connecting, setConnecting] = useState(false);
   const [envEntries, setEnvEntries] = useState<EnvVarEntry[]>([]);
@@ -198,7 +198,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
 
   const addTab = () => {
     const newId = Date.now();
-    setTabs((prev) => [...prev, { id: newId, connected: false, label: t("shell.defaultTabLabel", { n: (prev.length + 1).toString() }) }]);
+    setTabs((prev) => [...prev, { id: newId, connected: false }]);
     setActiveTab(newId);
   };
 
@@ -349,7 +349,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
       } else {
         termRefs.current.clear();
         const newId = Date.now();
-        setTabs([{ id: newId, connected: false, label: t("shell.defaultTabLabel", { n: "1" }) }]);
+        setTabs([{ id: newId, connected: false }]);
         setActiveTab(newId);
       }
     };
@@ -386,7 +386,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
     verifyUuidRef.current = verifyInstallUuid;
 
     const newId = Date.now();
-    setTabs((prev) => [...prev, { id: newId, connected: false, label: "Verifying..." }]);
+    setTabs((prev) => [...prev, { id: newId, connected: false, customLabel: "Verifying..." }]);
     setActiveTab(newId);
     getOrCreateTerm(newId);
     setInstallingTabIds((prev) => new Set(prev).add(newId));
@@ -414,10 +414,10 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
         });
         if (event.payload.success) {
           entry?.term.write("\r\n\x1b[32m\u2713 Installation complete\x1b[0m\r\n");
-          setTabs((prev) => prev.map((t) => (t.id === newId ? { ...t, label: "Install \u2713" } : t)));
+          setTabs((prev) => prev.map((t) => (t.id === newId ? { ...t, customLabel: "Install \u2713" } : t)));
         } else {
           entry?.term.write("\r\n\x1b[31m\u2717 Installation failed\x1b[0m\r\n");
-          setTabs((prev) => prev.map((t) => (t.id === newId ? { ...t, label: "Install \u2717" } : t)));
+          setTabs((prev) => prev.map((t) => (t.id === newId ? { ...t, customLabel: "Install \u2717" } : t)));
         }
         unlistenOutput.then((f) => f());
         unlistenDone.then((f) => f());
@@ -434,7 +434,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
   useEffect(() => {
     if (!installUrl || !vmId) return;
     const newId = Date.now();
-    setTabs((prev) => [...prev, { id: newId, connected: false, label: t("shell.defaultTabLabel", { n: (prev.length + 1).toString() }) }]);
+    setTabs((prev) => [...prev, { id: newId, connected: false }]);
     setActiveTab(newId);
     getOrCreateTerm(newId);
     setInstallingTabIds((prev) => new Set(prev).add(newId));
@@ -462,6 +462,23 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
 
   const activeTabInfo = tabs.find((t) => t.id === activeTab);
   const activeEnabled = envEntries;
+
+  // Renumber default-labeled tabs by their display order so closing a tab collapses
+  // the numbering (Shell 2 becomes Shell 1 after Shell 1 is closed). Custom labels
+  // (Verifying..., Install ✓/✗) are preserved and skipped in the count.
+  const tabLabels = (() => {
+    const labels = new Map<number, string>();
+    let n = 0;
+    for (const tab of tabs) {
+      if (tab.customLabel) {
+        labels.set(tab.id, tab.customLabel);
+      } else {
+        n += 1;
+        labels.set(tab.id, t("shell.defaultTabLabel", { n: n.toString() }));
+      }
+    }
+    return labels;
+  })();
 
   const handleFunctionKey = async (bash: string) => {
     const tab = tabs.find((t) => t.id === activeTab);
@@ -559,7 +576,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
             }}
             onClick={() => setActiveTab(tab.id)}
           >
-            <span>{tab.label}</span>
+            <span>{tabLabels.get(tab.id)}</span>
             {tabs.length > 1 && (
               <button
                 onClick={(e) => {


### PR DESCRIPTION
## Summary
- Closes #33
- Tab labels were stored at construction time, so closing "Shell 1" left a lone "Shell 2"
- Derive the displayed `Shell N` label from the live position of default-labeled tabs each render
- Custom labels (`Verifying...`, `Install ✓/✗`) move to a separate `customLabel` field so they're preserved and skipped in the count

## Test plan
- [x] Open three tabs → labels are `Shell 1`, `Shell 2`, `Shell 3`
- [x] Close `Shell 2` → remaining tabs become `Shell 1`, `Shell 2`
- [x] Close `Shell 1` → the remaining tab becomes `Shell 1`
- [x] Install an app from Store → installing tab keeps its `Install ✓` / `Install ✗` label and isn't counted in the `Shell N` numbering
- [x] Switch VMs → cached tab state restores with correct re-derived numbering