### PR TITLE
fix: clear shell input line on Esc (#34)

### DIFF
--- a/apps/nilbox/src/components/screens/Shell.tsx
+++ b/apps/nilbox/src/components/screens/Shell.tsx
@@ -63,6 +63,7 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
     resizeObserver?: ResizeObserver;
     sessionId?: number;
     imeShimCleanup?: () => void;
+    imeShimReset?: () => void;
   }>>(new Map());
 
   /**
@@ -138,11 +139,18 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
     textarea.addEventListener("blur", onBlur);
     textarea.addEventListener("keydown", onKeyDown);
 
+    entry.imeShimReset = () => {
+      lastSent = "";
+      xtermHandledKey = false;
+      textarea.value = "";
+    };
+
     entry.imeShimCleanup = () => {
       root.removeEventListener("input", onInput, true);
       textarea.removeEventListener("blur", onBlur);
       textarea.removeEventListener("keydown", onKeyDown);
       entry.imeShimCleanup = undefined;
+      entry.imeShimReset = undefined;
     };
   };
 
@@ -152,6 +160,25 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
       const fit = new FitAddon();
       term.loadAddon(fit);
       termRefs.current.set(tabId, { term, fit, div: null });
+      // Esc clears the current shell input line (sends Ctrl+U) — matches Claude
+      // Code CLI muscle memory. Returning false stops xterm from forwarding the
+      // raw \x1b. Skipped during IME composition so the IME's own cancel works.
+      term.attachCustomKeyEventHandler((ev) => {
+        if (
+          ev.type === "keydown" &&
+          ev.key === "Escape" &&
+          !ev.isComposing &&
+          ev.keyCode !== 229
+        ) {
+          const e = termRefs.current.get(tabId);
+          if (e?.sessionId != null) {
+            writeShell(e.sessionId, [0x15]).catch(() => {});
+          }
+          e?.imeShimReset?.();
+          return false;
+        }
+        return true;
+      });
     }
     return termRefs.current.get(tabId)!;
   };


### PR DESCRIPTION
## Summary
- Closes #34
- xterm forwards Esc as raw `\x1b`, which is a no-op on default emacs-mode readline — the half-typed line just sits there
- Intercept Esc via `term.attachCustomKeyEventHandler` and send `Ctrl+U` (`\x15`) instead, matching Claude Code CLI muscle memory
- Skipped during IME composition (`isComposing` / `keyCode 229`) so the IME's own cancel still works
- Resets the macOS IME shim's mirrored textarea/`lastSent` state so the next composed character doesn't emit stale erase bytes against the freshly-cleared prompt

## Trade-off
This is unconditional — vi-mode users (`set -o vi`) lose Esc-to-normal-mode in the remote shell. The client can't detect remote shell mode, so this matches the issue's "Esc-to-clear convention in modern AI CLI tooling" framing. We can gate this behind a setting later if anyone speaks up.

## Test plan
- [ ] Type `echo hello world`, press Esc → input line clears, prompt is empty
- [ ] Type a long command, press Esc → cleared in one shot (no held Backspace needed)
- [ ] Start Hangul composition (`ㅎ`, `ㅏ`), press Esc → IME composition cancels (no Ctrl+U sent), shell line untouched
- [ ] Commit a Hangul syllable (`한`) then press Esc → line clears
- [ ] Open multiple shell tabs, verify Esc clears the active tab only