### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,7 +3470,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nilbox"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "nilbox-blocklist"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "nilbox-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "nilbox-mcp-bridge"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "GPL-3.0-or-later"
 

--- a/apps/nilbox/src-tauri/tauri.conf.json
+++ b/apps/nilbox/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "nilbox",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "run.nilbox.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
Bump the project version from 0.2.2 to 0.2.3

## Changes
- Updated version in Cargo.toml
- Updated version in Cargo.lock
- Updated version in tauri.conf.json

Closes #39