### PR TITLE
feat: implement FUSE rename operation (#44)

### DIFF
--- a/crates/nilbox-core/src/file_proxy/handler.rs
+++ b/crates/nilbox-core/src/file_proxy/handler.rs
@@ -195,6 +195,9 @@ impl FileProxy {
             FuseRequest::Remove { request_id, is_dir, path } => {
                 self.handle_remove(request_id, is_dir, &path).await
             }
+            FuseRequest::Rename { request_id, old_path, new_path } => {
+                self.handle_rename(request_id, &old_path, &new_path).await
+            }
             FuseRequest::PathQuery { request_id } => {
                 self.handle_path_query(request_id).await
             }
@@ -487,6 +490,28 @@ impl FileProxy {
         match result {
             Ok(()) => FuseResponse::Remove { request_id, status: StatusCode::Ok },
             Err(e) => FuseResponse::Remove { request_id, status: StatusCode::from(e.kind()) },
+        }
+    }
+
+    async fn handle_rename(&self, request_id: RequestId, old_path: &str, new_path: &str) -> FuseResponse {
+        if self.read_only {
+            return FuseResponse::Rename { request_id, status: StatusCode::ErrAccess };
+        }
+
+        let pm = self.path_manager.read().await;
+        let old_full = match pm.resolve_path(old_path) {
+            Ok(p) => p,
+            Err(_) => return FuseResponse::Rename { request_id, status: StatusCode::ErrNoent },
+        };
+        let new_full = match pm.validate_new_path(new_path) {
+            Ok(p) => p,
+            Err(_) => return FuseResponse::Rename { request_id, status: StatusCode::ErrSandboxed },
+        };
+        drop(pm);
+
+        match fs::rename(&old_full, &new_full) {
+            Ok(()) => FuseResponse::Rename { request_id, status: StatusCode::Ok },
+            Err(e) => FuseResponse::Rename { request_id, status: StatusCode::from(e.kind()) },
         }
     }
 

--- a/crates/nilbox-core/src/file_proxy/protocol.rs
+++ b/crates/nilbox-core/src/file_proxy/protocol.rs
@@ -132,6 +132,7 @@ pub enum FuseRequest {
     Stat { request_id: RequestId, path: String },
     Mkdir { request_id: RequestId, mode: u32, path: String },
     Remove { request_id: RequestId, is_dir: bool, path: String },
+    Rename { request_id: RequestId, old_path: String, new_path: String },
     PathQuery { request_id: RequestId },
     Ping { request_id: RequestId },
 }
@@ -147,6 +148,7 @@ impl FuseRequest {
             FuseRequest::Stat { request_id, .. } => *request_id,
             FuseRequest::Mkdir { request_id, .. } => *request_id,
             FuseRequest::Remove { request_id, .. } => *request_id,
+            FuseRequest::Rename { request_id, .. } => *request_id,
             FuseRequest::PathQuery { request_id } => *request_id,
             FuseRequest::Ping { request_id } => *request_id,
         }
@@ -164,6 +166,7 @@ pub enum FuseResponse {
     Stat { request_id: RequestId, status: StatusCode, attr: FileAttr },
     Mkdir { request_id: RequestId, status: StatusCode },
     Remove { request_id: RequestId, status: StatusCode },
+    Rename { request_id: RequestId, status: StatusCode },
     PathQuery { request_id: RequestId, status: StatusCode, state: u8, path: String },
     Pong { request_id: RequestId },
     // Host-initiated notifications
@@ -274,6 +277,14 @@ pub fn decode_request(src: &mut BytesMut) -> anyhow::Result<Option<FuseRequest>>
             let path = String::from_utf8(payload.split_to(path_len).to_vec())?;
             FuseRequest::Remove { request_id, is_dir, path }
         }
+        OpType::Rename => {
+            let request_id = payload.get_u64_le();
+            let old_len = payload.get_u16_le() as usize;
+            let old_path = String::from_utf8(payload.split_to(old_len).to_vec())?;
+            let new_len = payload.get_u16_le() as usize;
+            let new_path = String::from_utf8(payload.split_to(new_len).to_vec())?;
+            FuseRequest::Rename { request_id, old_path, new_path }
+        }
         OpType::PathQuery => {
             let request_id = payload.get_u64_le();
             FuseRequest::PathQuery { request_id }
@@ -348,6 +359,11 @@ pub fn encode_response(resp: &FuseResponse) -> BytesMut {
         }
         FuseResponse::Remove { request_id, status } => {
             op_type = OpType::Remove as u16;
+            payload.put_u64_le(*request_id);
+            payload.put_u16_le(*status as u16);
+        }
+        FuseResponse::Rename { request_id, status } => {
+            op_type = OpType::Rename as u16;
             payload.put_u64_le(*request_id);
             payload.put_u16_le(*status as u16);
         }

--- a/vm-agent/src/fuse/dispatcher.rs
+++ b/vm-agent/src/fuse/dispatcher.rs
@@ -251,6 +251,15 @@ impl RequestDispatcher {
         }
     }
 
+    pub async fn rename(&self, old_path: String, new_path: String) -> Result<(), DispatcherError> {
+        let request = FuseRequest::Rename { request_id: self.allocate_id(), old_path, new_path };
+        match self.send_request(request).await? {
+            FuseResponse::Rename { status, .. } if status == StatusCode::Ok => Ok(()),
+            FuseResponse::Rename { status, .. } => Err(DispatcherError::StatusError(status)),
+            _ => Err(DispatcherError::ProtocolError("Unexpected response".into())),
+        }
+    }
+
     pub async fn ping(&self) -> Result<(), DispatcherError> {
         let request = FuseRequest::Ping { request_id: self.allocate_id() };
         match self.send_request(request).await? {

--- a/vm-agent/src/fuse/filesystem.rs
+++ b/vm-agent/src/fuse/filesystem.rs
@@ -60,6 +60,18 @@ impl InodeMap {
             self.ino_to_path.remove(&ino);
         }
     }
+
+    /// Remap an inode from `old_path` to `new_path`, dropping any inode that
+    /// previously occupied the destination (overwrite case).
+    fn rename(&mut self, old_path: &str, new_path: &str) {
+        if let Some(dest_ino) = self.path_to_ino.remove(new_path) {
+            self.ino_to_path.remove(&dest_ino);
+        }
+        if let Some(ino) = self.path_to_ino.remove(old_path) {
+            self.ino_to_path.insert(ino, new_path.to_string());
+            self.path_to_ino.insert(new_path.to_string(), ino);
+        }
+    }
 }
 
 /// Local fh <-> remote fd mapping
@@ -643,6 +655,51 @@ impl Filesystem for HostFilesystem {
                     {
                         let mut inodes = inodes.lock().await;
                         inodes.remove(&path);
+                    }
+                    reply.ok();
+                }
+                Err(e) => { reply.error(Self::err_to_errno(&e)); }
+            }
+        });
+    }
+
+    fn rename(
+        &mut self, _req: &Request, parent: u64, name: &OsStr,
+        newparent: u64, newname: &OsStr, _flags: u32, reply: ReplyEmpty,
+    ) {
+        let dispatcher = self.dispatcher.clone();
+        let cache = self.cache.clone();
+        let inodes = self.inodes.clone();
+        let name = name.to_owned();
+        let newname = newname.to_owned();
+
+        self.rt.spawn(async move {
+            let (old_path, new_path) = {
+                let inodes = inodes.lock().await;
+                let parent_path = match inodes.get_path(parent) {
+                    Some(p) => p.clone(),
+                    None => { reply.error(ENOENT); return; }
+                };
+                let newparent_path = match inodes.get_path(newparent) {
+                    Some(p) => p.clone(),
+                    None => { reply.error(ENOENT); return; }
+                };
+                (
+                    Self::build_path(&parent_path, &name),
+                    Self::build_path(&newparent_path, &newname),
+                )
+            };
+
+            match dispatcher.rename(old_path.clone(), new_path.clone()).await {
+                Ok(()) => {
+                    {
+                        let mut c = cache.lock().await;
+                        c.invalidate_with_parent(&old_path);
+                        c.invalidate_with_parent(&new_path);
+                    }
+                    {
+                        let mut inodes = inodes.lock().await;
+                        inodes.rename(&old_path, &new_path);
                     }
                     reply.ok();
                 }

--- a/vm-agent/src/fuse/protocol.rs
+++ b/vm-agent/src/fuse/protocol.rs
@@ -171,6 +171,7 @@ pub enum FuseRequest {
     Stat { request_id: RequestId, path: String },
     Mkdir { request_id: RequestId, mode: u32, path: String },
     Remove { request_id: RequestId, is_dir: bool, path: String },
+    Rename { request_id: RequestId, old_path: String, new_path: String },
     PathQuery { request_id: RequestId },
     Ping { request_id: RequestId },
 }
@@ -186,6 +187,7 @@ impl FuseRequest {
             FuseRequest::Stat { request_id, .. } => *request_id,
             FuseRequest::Mkdir { request_id, .. } => *request_id,
             FuseRequest::Remove { request_id, .. } => *request_id,
+            FuseRequest::Rename { request_id, .. } => *request_id,
             FuseRequest::PathQuery { request_id } => *request_id,
             FuseRequest::Ping { request_id } => *request_id,
         }
@@ -201,6 +203,7 @@ impl FuseRequest {
             FuseRequest::Stat { .. } => OpType::Stat,
             FuseRequest::Mkdir { .. } => OpType::Mkdir,
             FuseRequest::Remove { .. } => OpType::Remove,
+            FuseRequest::Rename { .. } => OpType::Rename,
             FuseRequest::PathQuery { .. } => OpType::PathQuery,
             FuseRequest::Ping { .. } => OpType::Ping,
         }
@@ -218,6 +221,7 @@ pub enum FuseResponse {
     Stat { request_id: RequestId, status: StatusCode, file_type: FileType, mode: u32, size: u64, mtime: u64, atime: u64, ctime: u64 },
     Mkdir { request_id: RequestId, status: StatusCode },
     Remove { request_id: RequestId, status: StatusCode },
+    Rename { request_id: RequestId, status: StatusCode },
     PathQuery { request_id: RequestId, status: StatusCode, state: u8, path: String },
     Pong { request_id: RequestId },
 }
@@ -233,6 +237,7 @@ impl FuseResponse {
             FuseResponse::Stat { request_id, .. } => *request_id,
             FuseResponse::Mkdir { request_id, .. } => *request_id,
             FuseResponse::Remove { request_id, .. } => *request_id,
+            FuseResponse::Rename { request_id, .. } => *request_id,
             FuseResponse::PathQuery { request_id, .. } => *request_id,
             FuseResponse::Pong { request_id } => *request_id,
         }
@@ -248,6 +253,7 @@ impl FuseResponse {
             FuseResponse::Stat { status, .. } => *status,
             FuseResponse::Mkdir { status, .. } => *status,
             FuseResponse::Remove { status, .. } => *status,
+            FuseResponse::Rename { status, .. } => *status,
             FuseResponse::PathQuery { status, .. } => *status,
             FuseResponse::Pong { .. } => StatusCode::Ok,
         }
@@ -335,6 +341,16 @@ pub fn encode_request(req: &FuseRequest) -> BytesMut {
             let path_bytes = path.as_bytes();
             payload.put_u16_le(path_bytes.len() as u16);
             payload.put_slice(path_bytes);
+        }
+        FuseRequest::Rename { request_id, old_path, new_path } => {
+            op_type = OpType::Rename as u16;
+            payload.put_u64_le(*request_id);
+            let old_bytes = old_path.as_bytes();
+            payload.put_u16_le(old_bytes.len() as u16);
+            payload.put_slice(old_bytes);
+            let new_bytes = new_path.as_bytes();
+            payload.put_u16_le(new_bytes.len() as u16);
+            payload.put_slice(new_bytes);
         }
         FuseRequest::PathQuery { request_id } => {
             op_type = OpType::PathQuery as u16;
@@ -440,6 +456,11 @@ pub fn decode_response(src: &mut BytesMut) -> anyhow::Result<Option<FuseMessage>
             let request_id = payload.get_u64_le();
             let status = StatusCode::try_from(payload.get_u16_le())?;
             FuseMessage::Response(FuseResponse::Remove { request_id, status })
+        }
+        OpType::Rename => {
+            let request_id = payload.get_u64_le();
+            let status = StatusCode::try_from(payload.get_u16_le())?;
+            FuseMessage::Response(FuseResponse::Rename { request_id, status })
         }
         OpType::PathQuery => {
             let request_id = payload.get_u64_le();


### PR DESCRIPTION
## Summary
FUSE `rename` 연산을 게스트↔호스트 전체 스택에 구현합니다. `OpType::Rename = 0x0009` 코드 포인트는 이미 양쪽 프로토콜에 정의돼 있었으나, 요청/응답 타입과 핸들러가 없어 rename 시 오류가 발생했습니다.

## Changes

### Guest (`vm-agent/src/fuse/`)
- **protocol.rs**: `FuseRequest::Rename` / `FuseResponse::Rename` 추가, encode/decode 처리
- **dispatcher.rs**: `rename()` 편의 메서드
- **filesystem.rs**: `Filesystem::rename` 구현 — inode를 새 경로로 리매핑, 양쪽 부모 디렉터리 캐시 무효화

### Host (`crates/nilbox-core/src/file_proxy/`)
- **protocol.rs**: `FuseRequest::Rename` / `FuseResponse::Rename` 추가, decode/encode 처리
- **handler.rs**: `handle_rename` — read-only 체크, 샌드박스 검증(`resolve_path`/`validate_new_path`), `fs::rename` 실행

## Wire format
`request_id(u64) + old_path(u16 len+bytes) + new_path(u16 len+bytes)`

## Notes
- rename 플래그(`RENAME_NOREPLACE`/`RENAME_EXCHANGE`)는 다른 연산과의 일관성을 위해 전송하지 않으며, 호스트는 POSIX 기본 동작(`fs::rename`, 덮어쓰기)으로 처리합니다.
- 디렉터리 rename 시 자식 경로 inode는 stale해지지만 캐시 무효화 + 커널 재조회로 정합성이 유지됩니다.

## Test
- `cargo check --workspace --exclude vm-agent` 통과 (호스트 측 컴파일 확인)
- vm-agent의 FUSE 코드는 `#[cfg(all(target_os = "linux", feature = "with-fuse"))]` 게이팅으로 Linux 타겟에서만 컴파일됩니다.

Closes #44