### PR TITLE
fix: prevent duplicated paste/drop input in terminal shell

### DIFF
--- a/apps/nilbox/src/components/screens/Shell.tsx
+++ b/apps/nilbox/src/components/screens/Shell.tsx
@@ -103,6 +103,15 @@ export const Shell: React.FC<Props> = ({ vmId, sshReady = false, installUrl, onI
     const onInput = (event: Event) => {
       if (event.target !== textarea) return;
       const cur = textarea.value;
+      // Paste/drop are handled natively by xterm (which forwards via onData).
+      // Skip them here so the shim doesn't re-send and duplicate the content,
+      // but keep lastSent in sync so later diffs stay correct.
+      const inputType = (event as InputEvent).inputType;
+      if (inputType === "insertFromPaste" || inputType === "insertFromDrop") {
+        lastSent = cur;
+        event.stopPropagation();
+        return;
+      }
       if (xtermHandledKey || (term as unknown as { _keyPressHandled: boolean })._keyPressHandled) {
         lastSent = cur;
         xtermHandledKey = false;


### PR DESCRIPTION
## Summary
- Paste and drop are already forwarded to the PTY via xterm's `onData` handler
- The input shim in `Shell.tsx` was re-sending that same content, causing duplication
- Skip `insertFromPaste`/`insertFromDrop` input events in the shim while keeping `lastSent` in sync

Fixes #46

## Test plan
- [ ] Paste text into the terminal and confirm it appears once, not duplicated
- [ ] Drag-and-drop text/file path into the terminal and confirm no duplication
- [ ] Confirm normal typing still works as expected