### PR TITLE
fix: implement FUSE truncate to prevent stale trailing bytes on re-write

### DIFF
--- a/crates/nilbox-core/src/file_proxy/handler.rs
+++ b/crates/nilbox-core/src/file_proxy/handler.rs
@@ -198,6 +198,9 @@ impl FileProxy {
             FuseRequest::Rename { request_id, old_path, new_path } => {
                 self.handle_rename(request_id, &old_path, &new_path).await
             }
+            FuseRequest::Truncate { request_id, path, size } => {
+                self.handle_truncate(request_id, &path, size).await
+            }
             FuseRequest::PathQuery { request_id } => {
                 self.handle_path_query(request_id).await
             }
@@ -325,8 +328,8 @@ impl FileProxy {
             return FuseResponse::Write { request_id, status: StatusCode::from(e.kind()), written: 0 };
         }
 
-        match open_file.file.write(&data) {
-            Ok(n) => FuseResponse::Write { request_id, status: StatusCode::Ok, written: n as u32 },
+        match open_file.file.write_all(&data) {
+            Ok(()) => FuseResponse::Write { request_id, status: StatusCode::Ok, written: data.len() as u32 },
             Err(e) => FuseResponse::Write { request_id, status: StatusCode::from(e.kind()), written: 0 },
         }
     }
@@ -512,6 +515,29 @@ impl FileProxy {
         match fs::rename(&old_full, &new_full) {
             Ok(()) => FuseResponse::Rename { request_id, status: StatusCode::Ok },
             Err(e) => FuseResponse::Rename { request_id, status: StatusCode::from(e.kind()) },
+        }
+    }
+
+    async fn handle_truncate(&self, request_id: RequestId, path: &str, size: u64) -> FuseResponse {
+        if self.read_only {
+            return FuseResponse::Truncate { request_id, status: StatusCode::ErrAccess };
+        }
+
+        let pm = self.path_manager.read().await;
+        let full_path = match pm.resolve_path(path) {
+            Ok(p) => p,
+            Err(_) => return FuseResponse::Truncate { request_id, status: StatusCode::ErrNoent },
+        };
+        drop(pm);
+
+        let file = match OpenOptions::new().write(true).open(&full_path) {
+            Ok(f) => f,
+            Err(e) => return FuseResponse::Truncate { request_id, status: StatusCode::from(e.kind()) },
+        };
+
+        match file.set_len(size) {
+            Ok(()) => FuseResponse::Truncate { request_id, status: StatusCode::Ok },
+            Err(e) => FuseResponse::Truncate { request_id, status: StatusCode::from(e.kind()) },
         }
     }
 

--- a/crates/nilbox-core/src/file_proxy/protocol.rs
+++ b/crates/nilbox-core/src/file_proxy/protocol.rs
@@ -133,6 +133,7 @@ pub enum FuseRequest {
     Mkdir { request_id: RequestId, mode: u32, path: String },
     Remove { request_id: RequestId, is_dir: bool, path: String },
     Rename { request_id: RequestId, old_path: String, new_path: String },
+    Truncate { request_id: RequestId, path: String, size: u64 },
     PathQuery { request_id: RequestId },
     Ping { request_id: RequestId },
 }
@@ -149,6 +150,7 @@ impl FuseRequest {
             FuseRequest::Mkdir { request_id, .. } => *request_id,
             FuseRequest::Remove { request_id, .. } => *request_id,
             FuseRequest::Rename { request_id, .. } => *request_id,
+            FuseRequest::Truncate { request_id, .. } => *request_id,
             FuseRequest::PathQuery { request_id } => *request_id,
             FuseRequest::Ping { request_id } => *request_id,
         }
@@ -167,6 +169,7 @@ pub enum FuseResponse {
     Mkdir { request_id: RequestId, status: StatusCode },
     Remove { request_id: RequestId, status: StatusCode },
     Rename { request_id: RequestId, status: StatusCode },
+    Truncate { request_id: RequestId, status: StatusCode },
     PathQuery { request_id: RequestId, status: StatusCode, state: u8, path: String },
     Pong { request_id: RequestId },
     // Host-initiated notifications
@@ -285,6 +288,13 @@ pub fn decode_request(src: &mut BytesMut) -> anyhow::Result<Option<FuseRequest>>
             let new_path = String::from_utf8(payload.split_to(new_len).to_vec())?;
             FuseRequest::Rename { request_id, old_path, new_path }
         }
+        OpType::Truncate => {
+            let request_id = payload.get_u64_le();
+            let size = payload.get_u64_le();
+            let path_len = payload.get_u16_le() as usize;
+            let path = String::from_utf8(payload.split_to(path_len).to_vec())?;
+            FuseRequest::Truncate { request_id, path, size }
+        }
         OpType::PathQuery => {
             let request_id = payload.get_u64_le();
             FuseRequest::PathQuery { request_id }
@@ -364,6 +374,11 @@ pub fn encode_response(resp: &FuseResponse) -> BytesMut {
         }
         FuseResponse::Rename { request_id, status } => {
             op_type = OpType::Rename as u16;
+            payload.put_u64_le(*request_id);
+            payload.put_u16_le(*status as u16);
+        }
+        FuseResponse::Truncate { request_id, status } => {
+            op_type = OpType::Truncate as u16;
             payload.put_u64_le(*request_id);
             payload.put_u16_le(*status as u16);
         }

--- a/vm-agent/src/fuse/dispatcher.rs
+++ b/vm-agent/src/fuse/dispatcher.rs
@@ -206,6 +206,15 @@ impl RequestDispatcher {
         }
     }
 
+    pub async fn truncate(&self, path: String, size: u64) -> Result<(), DispatcherError> {
+        let request = FuseRequest::Truncate { request_id: self.allocate_id(), path, size };
+        match self.send_request(request).await? {
+            FuseResponse::Truncate { status, .. } if status == StatusCode::Ok => Ok(()),
+            FuseResponse::Truncate { status, .. } => Err(DispatcherError::StatusError(status)),
+            _ => Err(DispatcherError::ProtocolError("Unexpected response".into())),
+        }
+    }
+
     pub async fn close(&self, fd: u64) -> Result<(), DispatcherError> {
         let request = FuseRequest::Close { request_id: self.allocate_id(), fd };
         match self.send_request(request).await? {

--- a/vm-agent/src/fuse/filesystem.rs
+++ b/vm-agent/src/fuse/filesystem.rs
@@ -717,7 +717,6 @@ impl Filesystem for HostFilesystem {
         _bkuptime: Option<SystemTime>, _flags: Option<u32>,
         reply: ReplyAttr,
     ) {
-        // For now, just return current attributes (truncate not yet supported)
         let dispatcher = self.dispatcher.clone();
         let cache = self.cache.clone();
         let inodes = self.inodes.clone();
@@ -730,6 +729,15 @@ impl Filesystem for HostFilesystem {
                     None => { reply.error(ENOENT); return; }
                 }
             };
+
+            if let Some(new_size) = size {
+                if let Err(e) = dispatcher.truncate(path.clone(), new_size).await {
+                    reply.error(Self::err_to_errno(&e));
+                    return;
+                }
+                let mut c = cache.lock().await;
+                c.invalidate(&path);
+            }
 
             match dispatcher.stat(path.clone()).await {
                 Ok(FuseResponse::Stat { file_type, mode, size: file_size, mtime, atime, ctime, .. }) => {

--- a/vm-agent/src/fuse/protocol.rs
+++ b/vm-agent/src/fuse/protocol.rs
@@ -172,6 +172,7 @@ pub enum FuseRequest {
     Mkdir { request_id: RequestId, mode: u32, path: String },
     Remove { request_id: RequestId, is_dir: bool, path: String },
     Rename { request_id: RequestId, old_path: String, new_path: String },
+    Truncate { request_id: RequestId, path: String, size: u64 },
     PathQuery { request_id: RequestId },
     Ping { request_id: RequestId },
 }
@@ -188,6 +189,7 @@ impl FuseRequest {
             FuseRequest::Mkdir { request_id, .. } => *request_id,
             FuseRequest::Remove { request_id, .. } => *request_id,
             FuseRequest::Rename { request_id, .. } => *request_id,
+            FuseRequest::Truncate { request_id, .. } => *request_id,
             FuseRequest::PathQuery { request_id } => *request_id,
             FuseRequest::Ping { request_id } => *request_id,
         }
@@ -204,6 +206,7 @@ impl FuseRequest {
             FuseRequest::Mkdir { .. } => OpType::Mkdir,
             FuseRequest::Remove { .. } => OpType::Remove,
             FuseRequest::Rename { .. } => OpType::Rename,
+            FuseRequest::Truncate { .. } => OpType::Truncate,
             FuseRequest::PathQuery { .. } => OpType::PathQuery,
             FuseRequest::Ping { .. } => OpType::Ping,
         }
@@ -222,6 +225,7 @@ pub enum FuseResponse {
     Mkdir { request_id: RequestId, status: StatusCode },
     Remove { request_id: RequestId, status: StatusCode },
     Rename { request_id: RequestId, status: StatusCode },
+    Truncate { request_id: RequestId, status: StatusCode },
     PathQuery { request_id: RequestId, status: StatusCode, state: u8, path: String },
     Pong { request_id: RequestId },
 }
@@ -238,6 +242,7 @@ impl FuseResponse {
             FuseResponse::Mkdir { request_id, .. } => *request_id,
             FuseResponse::Remove { request_id, .. } => *request_id,
             FuseResponse::Rename { request_id, .. } => *request_id,
+            FuseResponse::Truncate { request_id, .. } => *request_id,
             FuseResponse::PathQuery { request_id, .. } => *request_id,
             FuseResponse::Pong { request_id } => *request_id,
         }
@@ -254,6 +259,7 @@ impl FuseResponse {
             FuseResponse::Mkdir { status, .. } => *status,
             FuseResponse::Remove { status, .. } => *status,
             FuseResponse::Rename { status, .. } => *status,
+            FuseResponse::Truncate { status, .. } => *status,
             FuseResponse::PathQuery { status, .. } => *status,
             FuseResponse::Pong { .. } => StatusCode::Ok,
         }
@@ -351,6 +357,14 @@ pub fn encode_request(req: &FuseRequest) -> BytesMut {
             let new_bytes = new_path.as_bytes();
             payload.put_u16_le(new_bytes.len() as u16);
             payload.put_slice(new_bytes);
+        }
+        FuseRequest::Truncate { request_id, path, size } => {
+            op_type = OpType::Truncate as u16;
+            payload.put_u64_le(*request_id);
+            payload.put_u64_le(*size);
+            let path_bytes = path.as_bytes();
+            payload.put_u16_le(path_bytes.len() as u16);
+            payload.put_slice(path_bytes);
         }
         FuseRequest::PathQuery { request_id } => {
             op_type = OpType::PathQuery as u16;
@@ -461,6 +475,11 @@ pub fn decode_response(src: &mut BytesMut) -> anyhow::Result<Option<FuseMessage>
             let request_id = payload.get_u64_le();
             let status = StatusCode::try_from(payload.get_u16_le())?;
             FuseMessage::Response(FuseResponse::Rename { request_id, status })
+        }
+        OpType::Truncate => {
+            let request_id = payload.get_u64_le();
+            let status = StatusCode::try_from(payload.get_u16_le())?;
+            FuseMessage::Response(FuseResponse::Truncate { request_id, status })
         }
         OpType::PathQuery => {
             let request_id = payload.get_u64_le();


### PR DESCRIPTION
## Summary
- `setattr()` previously ignored the requested `size` and just re-reported the current (stale) attributes as if `ftruncate`/`truncate` had succeeded, so a shorter re-write after truncation left old trailing bytes past the new EOF (only reproducible inside the FUSE mount, e.g. `git commit` followed quickly by `git commit --amend`).
- Wires up the previously-reserved `Truncate` opcode end-to-end: guest protocol (`vm-agent/src/fuse/protocol.rs`), dispatcher (`vm-agent/src/fuse/dispatcher.rs`), host protocol (`crates/nilbox-core/src/file_proxy/protocol.rs`), and host handler (`crates/nilbox-core/src/file_proxy/handler.rs`) using `File::set_len`.
- `setattr` now calls `dispatcher.truncate()` and invalidates the attr cache before replying, instead of silently no-opping.
- Hardens `handle_write` to use `write_all` instead of a single `write` call, since `Write::write` is allowed to short-write per its contract.

Fixes #48

## Test plan
- [x] `cargo check -p nilbox-core` — no errors
- [x] `cargo check --bin vm-agent` — no errors
- [ ] Manual repro inside a FUSE-mounted repo: `git commit -am "first"` then `git commit --amend -m "shorter"`, verify `git cat-file -p HEAD` has no trailing garbage